### PR TITLE
Added example notebook for scikit-learn

### DIFF
--- a/model_card_toolkit/documentation/examples/Scikit_Learn_Model_Card_Toolkit_Demo.ipynb
+++ b/model_card_toolkit/documentation/examples/Scikit_Learn_Model_Card_Toolkit_Demo.ipynb
@@ -1,0 +1,460 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "environment": {
+      "name": "tf2-gpu.2-1.m46",
+      "type": "gcloud",
+      "uri": "gcr.io/deeplearning-platform-release/tf2-gpu.2-1:m46"
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.7.6"
+    },
+    "colab": {
+      "name": "Scikit_Learn_Model_Card_Toolkit_Demo.ipynb",
+      "provenance": []
+    }
+  },
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "uzshmL3siYjv",
+        "colab_type": "text"
+      },
+      "source": [
+        "##### Copyright © 2020 The TensorFlow Authors."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "15_lEO_CiYjw",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "#@title Licensed under the Apache License, Version 2.0 (the \"License\");\n",
+        "# you may not use this file except in compliance with the License.\n",
+        "# You may obtain a copy of the License at\n",
+        "#\n",
+        "# https://www.apache.org/licenses/LICENSE-2.0\n",
+        "#\n",
+        "# Unless required by applicable law or agreed to in writing, software\n",
+        "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
+        "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
+        "# See the License for the specific language governing permissions and\n",
+        "# limitations under the License."
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "A5epNF_aiYj0",
+        "colab_type": "text"
+      },
+      "source": [
+        "# Scikit-Learn Model Card Toolkit Demo\n",
+        "\n",
+        "## Background\n",
+        "This notebook demonstrates how to generate a model card using the Model Card Toolkit with a scikit-learn model in a Jupyter/Colab environment. You can learn more about model cards at [https://modelcards.withgoogle.com/about](https://modelcards.withgoogle.com/about).\n",
+        "\n",
+        "## Setup\n",
+        "We first need to install and import the necessary packages.\n",
+        "\n",
+        "### Upgrade Pip and Install Packages"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "cvF-yBM0iYj1",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "try:\n",
+        "    import colab\n",
+        "    !pip install --upgrade pip\n",
+        "except:\n",
+        "    pass"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "1OiOQJDPiYj3",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "!pip install -U seaborn\n",
+        "!pip install sklearn\n",
+        "!pip install model-card-toolkit"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "JpcNkrmLiYj7",
+        "colab_type": "text"
+      },
+      "source": [
+        "### Did you restart the runtime?\n",
+        "If you are using Google Colab, the first time that you run the cell above, you must restart the runtime (Runtime > Restart runtime ...). This is because of the way that Colab loads packages.\n",
+        "\n",
+        "### Import packages\n",
+        "We import necessary packages, including scikit-learn."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "y25vFI3WiYj7",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "from datetime import date\n",
+        "from io import BytesIO\n",
+        "from IPython import display\n",
+        "from model_card_toolkit import ModelCardToolkit\n",
+        "from sklearn.datasets import load_breast_cancer\n",
+        "from sklearn.ensemble import GradientBoostingClassifier\n",
+        "from sklearn.model_selection import train_test_split\n",
+        "from sklearn.metrics import plot_roc_curve, plot_confusion_matrix\n",
+        "\n",
+        "import base64\n",
+        "import matplotlib.pyplot as plt\n",
+        "import pandas as pd\n",
+        "import seaborn as sns\n",
+        "import uuid"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "XVdpINibiYj-",
+        "colab_type": "text"
+      },
+      "source": [
+        "## Load data\n",
+        "\n",
+        "This example uses the Breast Cancer Wisconsin Diagnostic dataset that scikit-learn can load using the [load_breast_cancer()](https://scikit-learn.org/stable/modules/generated/sklearn.datasets.load_breast_cancer.html) function."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "aR6kzqPeiYj_",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "cancer = load_breast_cancer()\n",
+        "\n",
+        "X = pd.DataFrame(cancer.data, columns=cancer.feature_names)\n",
+        "y = pd.Series(cancer.target)\n",
+        "\n",
+        "X_train, X_test, y_train, y_test = train_test_split(X, y)"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "DwjxhVtTiYkB",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "X_train.head()"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "fCOK-1gyiYkE",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "y_train.head()"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "KmOnApwWiYkG",
+        "colab_type": "text"
+      },
+      "source": [
+        "## Plot data\n",
+        "\n",
+        "We will create several plots from the data that we will include in the model card."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "O9n6rAV7iYkG",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "# Utility function that will export a plot to a base-64 encoded string that the model card will accept.\n",
+        "\n",
+        "def plot_to_str():\n",
+        "    img = BytesIO()\n",
+        "    plt.savefig(img, format='png')\n",
+        "    return base64.encodebytes(img.getvalue()).decode('utf-8')"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "lpZLJG3hiYkI",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "# Plot the mean radius feature for both the train and test sets\n",
+        "\n",
+        "sns.displot(x=X_train['mean radius'], hue=y_train)\n",
+        "mean_radius_train = plot_to_str()\n",
+        "\n",
+        "sns.displot(x=X_test['mean radius'], hue=y_test)\n",
+        "mean_radius_test = plot_to_str()"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "sFenUqQPiYkK",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "# Plot the mean texture feature for both the train and test sets\n",
+        "\n",
+        "sns.displot(x=X_train['mean texture'], hue=y_train)\n",
+        "mean_texture_train = plot_to_str()\n",
+        "\n",
+        "sns.displot(x=X_test['mean texture'], hue=y_test)\n",
+        "mean_texture_test = plot_to_str()"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "hA7QthuhiYkM",
+        "colab_type": "text"
+      },
+      "source": [
+        "## Train model"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "8VkTo7BxiYkN",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "# Create a classifier and fit the training data\n",
+        "\n",
+        "clf = GradientBoostingClassifier().fit(X_train, y_train)"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "7fo-7XlIiYkP",
+        "colab_type": "text"
+      },
+      "source": [
+        "## Evaluate model"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "_vEWAT2OiYkP",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "# Plot a ROC curve\n",
+        "\n",
+        "plot_roc_curve(clf, X_test, y_test)\n",
+        "roc_curve = plot_to_str()"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "QiNgUZKxiYkR",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "# Plot a confusion matrix\n",
+        "\n",
+        "plot_confusion_matrix(clf, X_test, y_test)\n",
+        "confusion_matrix = plot_to_str()"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "gN48E4y-iYkT",
+        "colab_type": "text"
+      },
+      "source": [
+        "## Create a model card"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "CBdRuxURiYkT",
+        "colab_type": "text"
+      },
+      "source": [
+        "### Initialize toolkit and model card"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "CI9ganKQiYkT",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "mct = ModelCardToolkit()\n",
+        "\n",
+        "model_card = mct.scaffold_assets()"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "CERQtrHWiYkV",
+        "colab_type": "text"
+      },
+      "source": [
+        "### Annotate information into model card"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "TLzNJ_kriYkV",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "model_card.model_details.name = 'Breast Cancer Wisconsin (Diagnostic) Dataset'\n",
+        "model_card.model_details.overview = '''This model predicts whether breast cancer is benign or malignant based on image measurements.'''\n",
+        "model_card.model_details.owners = [{'name': 'Model Cards Team', 'contact': 'model-cards@google.com'}]\n",
+        "model_card.model_details.references=['https://archive.ics.uci.edu/ml/datasets/Breast+Cancer+Wisconsin+(Diagnostic)','https://minds.wisconsin.edu/bitstream/handle/1793/59692/TR1131.pdf']\n",
+        "model_card.model_details.version.name = str(uuid.uuid4())\n",
+        "model_card.model_details.version.date = str(date.today())\n",
+        "\n",
+        "model_card.considerations.ethical_considerations = [{'name': 'Manual selection of image sections to digitize could create selection bias',\n",
+        "                                                     'mitigation_strategy': 'Automate the selection process'}]\n",
+        "model_card.considerations.limitations = ['Breast cancer diagnosis']\n",
+        "model_card.considerations.use_cases = ['Breast cancer diagnosis']\n",
+        "model_card.considerations.users = ['Medical professionals', 'ML researchers']\n",
+        "\n",
+        "\n",
+        "model_card.model_parameters.data.train.graphics.description = f'{len(X_train)} rows with {len(X_train.columns)} features'\n",
+        "model_card.model_parameters.data.train.graphics.collection = \\\n",
+        "                                                   [{'image': mean_radius_train},\n",
+        "                                                    {'image': mean_texture_train}]\n",
+        "model_card.model_parameters.data.eval.graphics.description = f'{len(X_test)} rows with {len(X_test.columns)} features'\n",
+        "model_card.model_parameters.data.eval.graphics.collection = \\\n",
+        "                                                   [{'image': mean_radius_test},\n",
+        "                                                    {'image': mean_texture_test}]\n",
+        "model_card.quantitative_analysis.graphics.description = 'ROC curve and confusion matrix'\n",
+        "model_card.quantitative_analysis.graphics.collection = \\\n",
+        "                                                   [{'image': roc_curve},\n",
+        "                                                    {'image': confusion_matrix}]\n",
+        "\n",
+        "mct.update_model_card_json(model_card)"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "TBqFqMHEiYkX",
+        "colab_type": "text"
+      },
+      "source": [
+        "## Generate model card"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "XUEG7n7ciYkY",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "\n",
+        "# Return the model card document as an HTML page\n",
+        "html = mct.export_format()\n",
+        "\n",
+        "display.display(display.HTML(html))"
+      ],
+      "execution_count": null,
+      "outputs": []
+    }
+  ]
+}


### PR DESCRIPTION
This notebook demonstrates that multiple ML frameworks, including scikit-learn, can be used to populate information in a model card. The end-to-end example loads data, builds a model, and then annotates a model card with model evaluation metrics and data visualizations.