### PR TITLE
Make it installable in python3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+build*
+dist*
+*.egg-info

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ REQUIRED_PACKAGES = [
     'tensorflow-model-analysis==0.24.3',
     'tensorflow-metadata==0.24.0',
     'ml-metadata==0.24.0',
+    'semantic-version==2.8.5',
 ]
 
 # Get version from version module.

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,6 @@ from setuptools import setup
 
 REQUIRED_PACKAGES = [
     'absl-py>=0.7,<0.9',
-    'semantic-version>=2.8.0,<3',
     'jinja2>=2.10,<3',
     'matplotlib>=3.2.0,<4',
     'jsonschema>=3.2.0,<4',
@@ -28,6 +27,7 @@ REQUIRED_PACKAGES = [
     'tensorflow-metadata==0.24.0',
     'ml-metadata==0.24.0',
     'semantic-version==2.8.5',
+    'Pygments==2.6.1',
 ]
 
 # Get version from version module.

--- a/setup.py
+++ b/setup.py
@@ -23,10 +23,10 @@ REQUIRED_PACKAGES = [
     'jinja2>=2.10,<3',
     'matplotlib>=3.2.0,<4',
     'jsonschema>=3.2.0,<4',
-    'tensorflow-data-validation>=0.21.0,<0.23',
-    'tensorflow-model-analysis>=0.21.0,<0.23',
-    'tensorflow-metadata>=0.21.0,<0.23',
-    'ml-metadata>=0.21.0,<0.23',
+    'tensorflow-data-validation==0.24.2',
+    'tensorflow-model-analysis==0.24.3',
+    'tensorflow-metadata==0.24.0',
+    'ml-metadata==0.24.0',
 ]
 
 # Get version from version module.


### PR DESCRIPTION
Currently, in python3 `setup.py` cannot be installed as the dependency requirements cannot be met for `tensorflow-data-validation`. This PR increases the dependency of the libraries to `0.24.x` to make it installeble against Python 3.8.