### PR TITLE
Fixes for markdown, model_card_json and ModelCardGenerator call

### DIFF
--- a/model_card_toolkit/documentation/examples/MLMD_Model_Card_Toolkit_Demo.ipynb
+++ b/model_card_toolkit/documentation/examples/MLMD_Model_Card_Toolkit_Demo.ipynb
@@ -14,7 +14,10 @@
       "execution_count": null,
       "metadata": {
         "cellView": "form",
-        "id": "tuOe1ymfHZPu"
+        "id": "tuOe1ymfHZPu",
+        "vscode": {
+          "languageId": "python"
+        }
       },
       "outputs": [],
       "source": [
@@ -95,15 +98,18 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "NYtxxdriz5VO",
+        "vscode": {
+          "languageId": "python"
+        }
+      },
+      "outputs": [],
       "source": [
         "!pip install --upgrade pip==21.3\n",
         "!pip install model-card-toolkit"
-      ],
-      "metadata": {
-        "id": "NYtxxdriz5VO"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -111,7 +117,7 @@
         "id": "EwT0nov5QO1M"
       },
       "source": [
-        "####*Did you restart the runtime?*\n",
+        "#### *Did you restart the runtime?*\n",
         "\n",
         "If you are using Google Colab, the runtime must be restarted after installing new packages."
       ]
@@ -131,7 +137,10 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "YIqpWK9efviJ"
+        "id": "YIqpWK9efviJ",
+        "vscode": {
+          "languageId": "python"
+        }
       },
       "outputs": [],
       "source": [
@@ -172,30 +181,36 @@
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "Ensure TensorFlow 2 is running and executing eagerly."
-      ],
       "metadata": {
         "id": "dDyZyTT02ysB"
-      }
+      },
+      "source": [
+        "Ensure TensorFlow 2 is running and executing eagerly."
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "XuUdIuFIwvZR",
+        "vscode": {
+          "languageId": "python"
+        }
+      },
+      "outputs": [],
       "source": [
         "tf.enable_v2_behavior()\n",
         "tf.executing_eagerly()"
-      ],
-      "metadata": {
-        "id": "XuUdIuFIwvZR"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "eZ4K18_DN2D8"
+        "id": "eZ4K18_DN2D8",
+        "vscode": {
+          "languageId": "python"
+        }
       },
       "outputs": [],
       "source": [
@@ -217,7 +232,10 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "ad5JLpKbf6sN"
+        "id": "ad5JLpKbf6sN",
+        "vscode": {
+          "languageId": "python"
+        }
       },
       "outputs": [],
       "source": [
@@ -242,7 +260,10 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "BywX6OUEhAqn"
+        "id": "BywX6OUEhAqn",
+        "vscode": {
+          "languageId": "python"
+        }
       },
       "outputs": [],
       "source": [
@@ -278,7 +299,10 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "c5YPeLPFOXaD"
+        "id": "c5YPeLPFOXaD",
+        "vscode": {
+          "languageId": "python"
+        }
       },
       "outputs": [],
       "source": [
@@ -299,7 +323,10 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "0Rh6K5sUf9dd"
+        "id": "0Rh6K5sUf9dd",
+        "vscode": {
+          "languageId": "python"
+        }
       },
       "outputs": [],
       "source": [
@@ -337,7 +364,10 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "PyXjuMt8f-9u"
+        "id": "PyXjuMt8f-9u",
+        "vscode": {
+          "languageId": "python"
+        }
       },
       "outputs": [],
       "source": [
@@ -349,7 +379,10 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "880KkTAkPeUg"
+        "id": "880KkTAkPeUg",
+        "vscode": {
+          "languageId": "python"
+        }
       },
       "outputs": [],
       "source": [
@@ -370,7 +403,10 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "H4XIXjiCPwzQ"
+        "id": "H4XIXjiCPwzQ",
+        "vscode": {
+          "languageId": "python"
+        }
       },
       "outputs": [],
       "source": [
@@ -407,7 +443,10 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "MAscCCYWgA-9"
+        "id": "MAscCCYWgA-9",
+        "vscode": {
+          "languageId": "python"
+        }
       },
       "outputs": [],
       "source": [
@@ -429,7 +468,10 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "tLjXy7K6Tp_G"
+        "id": "tLjXy7K6Tp_G",
+        "vscode": {
+          "languageId": "python"
+        }
       },
       "outputs": [],
       "source": [
@@ -451,7 +493,10 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "ygQvZ6hsiQ_J"
+        "id": "ygQvZ6hsiQ_J",
+        "vscode": {
+          "languageId": "python"
+        }
       },
       "outputs": [],
       "source": [
@@ -465,7 +510,10 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "Ec9vqDXpXeMb"
+        "id": "Ec9vqDXpXeMb",
+        "vscode": {
+          "languageId": "python"
+        }
       },
       "outputs": [],
       "source": [
@@ -499,7 +547,10 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "PuNSiUKb4YJf"
+        "id": "PuNSiUKb4YJf",
+        "vscode": {
+          "languageId": "python"
+        }
       },
       "outputs": [],
       "source": [
@@ -513,6 +564,9 @@
         "id": "HPjhXuIF4YJh",
         "jupyter": {
           "source_hidden": true
+        },
+        "vscode": {
+          "languageId": "python"
         }
       },
       "outputs": [],
@@ -552,7 +606,10 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "4AJ9hBs94YJm"
+        "id": "4AJ9hBs94YJm",
+        "vscode": {
+          "languageId": "python"
+        }
       },
       "outputs": [],
       "source": [
@@ -566,6 +623,9 @@
         "id": "MYmxxx9A4YJn",
         "jupyter": {
           "source_hidden": true
+        },
+        "vscode": {
+          "languageId": "python"
         }
       },
       "outputs": [],
@@ -642,7 +702,10 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "jHfhth_GiZI9"
+        "id": "jHfhth_GiZI9",
+        "vscode": {
+          "languageId": "python"
+        }
       },
       "outputs": [],
       "source": [
@@ -657,7 +720,10 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "SClrAaEGR1O5"
+        "id": "SClrAaEGR1O5",
+        "vscode": {
+          "languageId": "python"
+        }
       },
       "outputs": [],
       "source": [
@@ -678,7 +744,10 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "N1376oq04YJt"
+        "id": "N1376oq04YJt",
+        "vscode": {
+          "languageId": "python"
+        }
       },
       "outputs": [],
       "source": [
@@ -692,6 +761,9 @@
         "id": "nf9UuNng4YJu",
         "jupyter": {
           "source_hidden": true
+        },
+        "vscode": {
+          "languageId": "python"
         }
       },
       "outputs": [],
@@ -930,7 +1002,10 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "429-vvCWibO0"
+        "id": "429-vvCWibO0",
+        "vscode": {
+          "languageId": "python"
+        }
       },
       "outputs": [],
       "source": [
@@ -947,14 +1022,17 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "cSb8fhbQDmyJ",
+        "vscode": {
+          "languageId": "python"
+        }
+      },
+      "outputs": [],
       "source": [
         "trainer.outputs"
-      ],
-      "metadata": {
-        "id": "cSb8fhbQDmyJ"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -972,7 +1050,10 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "fVhfzzh9PDEx"
+        "id": "fVhfzzh9PDEx",
+        "vscode": {
+          "languageId": "python"
+        }
       },
       "outputs": [],
       "source": [
@@ -1017,18 +1098,21 @@
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "Warning: the Evaluator Component may take 5-10 minutes to run due to errors regarding \"inconsistent references\". "
-      ],
       "metadata": {
         "id": "QfbptwWQ4k0z"
-      }
+      },
+      "source": [
+        "Warning: the Evaluator Component may take 5-10 minutes to run due to errors regarding \"inconsistent references\". "
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "Zjcx8g6mihSt"
+        "id": "Zjcx8g6mihSt",
+        "vscode": {
+          "languageId": "python"
+        }
       },
       "outputs": [],
       "source": [
@@ -1047,7 +1131,10 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "k4GghePOTJxL"
+        "id": "k4GghePOTJxL",
+        "vscode": {
+          "languageId": "python"
+        }
       },
       "outputs": [],
       "source": [
@@ -1067,7 +1154,10 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "U729j5X5QQUQ"
+        "id": "U729j5X5QQUQ",
+        "vscode": {
+          "languageId": "python"
+        }
       },
       "outputs": [],
       "source": [
@@ -1076,74 +1166,67 @@
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "cdTLb_-8dLcu"
+      },
       "source": [
-        "###Model Card Generator\n",
+        "### Model Card Generator\n",
         "The `Model Card` component is a [TFX Component](https://www.tensorflow.org/tfx/guide/understanding_tfx_pipelines#component) that generates model cards-- short documentation that provides key information about a machine learning model-- from the StatisticGen outputs, the Evaluator outputs, and a prepared json annotation. Optionally, a pushed model or a template can be provided as well. \n",
         "\n",
         "The model cards assets are saved to a ModelCard artifact that can be fetched from the `outputs['model_card]'` property."
-      ],
-      "metadata": {
-        "id": "cdTLb_-8dLcu"
-      }
+      ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "l8LY5bMUJsuM"
+      },
       "source": [
         "#### Prepare Annotation Json for Model Card\n",
         "\n",
         "It is also important to document model information that might be important to downstream users, such as its limitations, intended use cases, trade offs, and ethical considerations. Thus, we will prepare this information in json format to be used in the model card generating step."
-      ],
-      "metadata": {
-        "id": "l8LY5bMUJsuM"
-      }
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "SIUiTor4Johj",
+        "vscode": {
+          "languageId": "python"
+        }
+      },
+      "outputs": [],
       "source": [
         "import json\n",
         "import model_card_toolkit as mctlib\n",
         "\n",
-        "model_card_json = {'model_details': {'name': 'Census Income Classifier'}, \n",
-        "                   'model_details': {'overview': \n",
-        "                      'This is a wide and deep Keras model which aims to classify whether or not '\n",
-        "                      'an individual has an income of over $50,000 based on various demographic '\n",
-        "                      'features. The model is trained on the UCI Census Income Dataset. This is '\n",
-        "                      'not a production model, and this dataset has traditionally only been used '\n",
-        "                      'for research purposes. In this Model Card, you can review quantitative '\n",
-        "                      'components of the model’s performance and data, as well as information '\n",
-        "                      'about the model’s intended uses, limitations, and ethical considerations.'},\n",
-        "                   'model_details': {'owners': [{\"name\": \"Model Cards Team\", \"contact\": \"model-cards@google.com\"}]},\n",
-        "                   'considerations': {'use_cases':[{\"description\":'This dataset that this model was trained on was originally created to '\n",
-        "                      'support the machine learning community in conducting empirical analysis '\n",
-        "                      'of ML algorithms. The Adult Data Set can be used in fairness-related '\n",
-        "                      'studies that compare inequalities across sex and race, based on '\n",
-        "                      'people’s annual incomes.'}]},\n",
-        "                   'considerations': {'limitations': [{'description':\n",
-        "                      'This is a class-imbalanced dataset across a variety of sensitive classes.'\n",
-        "                      ' The ratio of male-to-female examples is about 2:1 and there are far more'\n",
-        "                      ' examples with the “white” attribute than every other race combined. '\n",
-        "                      'Furthermore, the ratio of $50,000 or less earners to $50,000 or more '\n",
-        "                      'earners is just over 3:1. Due to the imbalance across income levels, we '\n",
-        "                      'can see that our true negative rate seems quite high, while our true '\n",
-        "                      'positive rate seems quite low. This is true to an even greater degree '\n",
-        "                      'when we only look at the “female” sub-group, because there are even '\n",
-        "                      'fewer female examples in the $50,000+ earner group, causing our model to '\n",
-        "                      'overfit these examples. To avoid this, we can try various remediation '\n",
-        "                      'strategies in future iterations (e.g. undersampling, hyperparameter '\n",
-        "                      'tuning, etc), but we may not be able to fix all of the fairness issues.'}]}, \n",
-        "                    'considerations': {'ethical_considerations': [\n",
-        "                                        {'name': 'We risk expressing the viewpoint that the attributes in this dataset '\n",
-        "                                                  'are the only ones that are predictive of someone’s income, even '\n",
-        "                                                  'though we know this is not the case.', \n",
-        "                                         'mitigation_strategy': 'As mentioned, some interventions may need to be '\n",
-        "                                            'performed to address the class imbalances in the dataset.'}]}\n",
-        "                  }"
-      ],
-      "metadata": {
-        "id": "SIUiTor4Johj"
-      },
-      "execution_count": null,
-      "outputs": []
+        "model_card_json = {\n",
+        "    'model_details': {\n",
+        "        'name': 'Census Income Classifier',\n",
+        "        'overview': 'This is a wide and deep Keras model which aims to classify whether or not an individual has an income of over $50,000 based on various demographic features. The model is trained on the UCI Census Income Dataset. This is not a production model, and this dataset has traditionally only been used for research purposes. In this Model Card, you can review quantitative components of the model’s performance and data, as well as information about the model’s intended uses, limitations, and ethical considerations.',\n",
+        "        'owners': [\n",
+        "            {\n",
+        "                'name': 'Model Cards Team',\n",
+        "                'contact': 'model-cards@google.com'\n",
+        "            }\n",
+        "        ],\n",
+        "    },\n",
+        "    'considerations': {\n",
+        "        'limitations': [\n",
+        "            {\n",
+        "                'description': 'This is a class-imbalanced dataset across a variety of sensitive classes. The ratio of male-to-female examples is about 2:1 and there are far more examples with the “white” attribute than every other race combined. Furthermore, the ratio of $50,000 or less earners to $50,000 or more earners is just over 3:1. Due to the imbalance across income levels, we can see that our true negative rate seems quite high, while our true positive rate seems quite low. This is true to an even greater degree when we only look at the “female” sub-group, because there are even fewer female examples in the $50,000+ earner group, causing our model to overfit these examples. To avoid this, we can try various remediation strategies in future iterations (e.g. undersampling, hyperparameter tuning, etc), but we may not be able to fix all of the fairness issues.'\n",
+        "            }\n",
+        "        ],\n",
+        "        'ethical_considerations': [\n",
+        "            {\n",
+        "                'name': 'We risk expressing the viewpoint that the attributes in this dataset are the only ones that are predictive of someone’s income, even though we know this is not the case.', \n",
+        "                'mitigation_strategy': 'As mentioned, some interventions may need to be performed to address the class imbalances in the dataset.'\n",
+        "            }\n",
+        "        ]\n",
+        "    }\n",
+        "}"
+      ]
     },
     {
       "cell_type": "markdown",
@@ -1151,52 +1234,61 @@
         "id": "SOYofSZKOMZx"
       },
       "source": [
-        "#### Generate the Model Card.\n"
+        "#### Generate the Model Card\n"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "bspjHq6u5aFf",
+        "vscode": {
+          "languageId": "python"
+        }
+      },
+      "outputs": [],
       "source": [
         "from model_card_toolkit.tfx.component import ModelCardGenerator\n",
         "\n",
-        "mct_gen = ModelCardGenerator(statistics=statistics_gen.outputs['statistics'],\n",
-        "                             evaluation=evaluator.outputs['evaluation'],\n",
+        "mct_gen = ModelCardGenerator(evaluation=evaluator.outputs['evaluation'],\n",
+        "                             statistics=statistics_gen.outputs['statistics'],\n",
         "                             json=json.dumps(model_card_json))\n",
         "context.run(mct_gen)\n"
-      ],
-      "metadata": {
-        "id": "bspjHq6u5aFf"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "euskJ-0qM6nV",
+        "vscode": {
+          "languageId": "python"
+        }
+      },
+      "outputs": [],
       "source": [
         "mct_gen.outputs['model_card']"
-      ],
-      "metadata": {
-        "id": "euskJ-0qM6nV"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "##Display Model Card\n",
-        "\n",
-        "Lastly, we isolate the uri from the model card generator artifact and use it to display the model card."
-      ],
       "metadata": {
         "id": "0kj1szHNdqrX"
-      }
+      },
+      "source": [
+        "## Display Model Card\n",
+        "\n",
+        "Lastly, we isolate the uri from the model card generator artifact and use it to display the model card."
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "Sd68Ih928vr9"
+        "id": "Sd68Ih928vr9",
+        "vscode": {
+          "languageId": "python"
+        }
       },
       "outputs": [],
       "source": [


### PR DESCRIPTION
- Fixed markdown syntax errors in headlines (added spaces so they would be rendered as headlines now)
- Fixed the model_card_json object according to the v0.0.2 schema (renders as anticipated now), prior to that it was not working as I expected it to be, see "Model Card for None" here: https://www.tensorflow.org/responsible_ai/model_card_toolkit/examples/MLMD_Model_Card_Toolkit_Demo#model_card_generator
- Switched the parameters evaluation and statistics in the ModelCardGenerator call according to its documentation (evaluation goes first, statistics second)
