### PR TITLE
Update broken link in Standalone_Model_Card_Toolkit_Demo.ipynb

### DIFF
--- a/model_card_toolkit/documentation/examples/Standalone_Model_Card_Toolkit_Demo.ipynb
+++ b/model_card_toolkit/documentation/examples/Standalone_Model_Card_Toolkit_Demo.ipynb
@@ -295,7 +295,7 @@
       "source": [
         "### Annotate the Model Card\n",
         "\n",
-        "The `ModelCard` object returned by `scaffold_assets()` has many fields that can be directly modified. These fields are rendered in the final generated Model Card document. For a comprehensive list, see [model_card.py](https://github.com/tensorflow/model-card-toolkit/blob/master/model_card_toolkit/model_card.py). See [the documentation](https://github.com/tensorflow/model-card-toolkit/blob/master/model_card_toolkit/documentation/concepts.md) for more details.\n"
+        "The `ModelCard` object returned by `scaffold_assets()` has many fields that can be directly modified. These fields are rendered in the final generated Model Card document. For a comprehensive list, see [model_card.py](https://github.com/tensorflow/model-card-toolkit/blob/master/model_card_toolkit/model_card.py). See [the documentation](https://github.com/tensorflow/model-card-toolkit/blob/master/model_card_toolkit/documentation/guide/concepts.md) for more details.\n"
       ]
     },
     {


### PR DESCRIPTION
Fixing a broken link in [this section](https://www.tensorflow.org/responsible_ai/model_card_toolkit/examples/Standalone_Model_Card_Toolkit_Demo#annotate_the_model_card), for the text  `the documentation`.