### PR TITLE
Make tests pytest and unittest compatible

### DIFF
--- a/model_card_toolkit/core_test.py
+++ b/model_card_toolkit/core_test.py
@@ -16,6 +16,7 @@
 import os
 from unittest import mock
 
+from absl import flags
 from absl.testing import absltest
 from absl.testing import parameterized
 
@@ -289,3 +290,7 @@ class CoreTest(parameterized.TestCase, TfxTest):
 
 if __name__ == '__main__':
   absltest.main()
+else:
+  # Manually pass and parse flags to prevent UnparsedFlagAccessError when using
+  # pytest or unittest as a runner.
+  flags.FLAGS(['--test_tmpdir'])

--- a/model_card_toolkit/utils/testdata/tfxtest.py
+++ b/model_card_toolkit/utils/testdata/tfxtest.py
@@ -16,6 +16,7 @@
 import os
 from typing import Any, Callable, List, Optional
 
+from absl import flags
 import apache_beam as beam
 from model_card_toolkit.utils.tfx_util import _TFX_METRICS_TYPE
 from model_card_toolkit.utils.tfx_util import _TFX_STATS_TYPE
@@ -174,3 +175,9 @@ class TfxTest(tfma.eval_saved_model.testutil.TensorflowModelAnalysisTest):
 
     if store:
       self._put_artifact(store, _TFX_STATS_TYPE, tfdv_path)
+
+
+if not __name__ == '__main__':
+  # Manually pass and parse flags to prevent UnparsedFlagAccessError when using
+  # pytest or unittest as a runner.
+  flags.FLAGS(['--test_tmpdir'])


### PR DESCRIPTION
# What does this pull request do?

This pull request enables running tests with pytest and unittest as the test runners. Previously, running tests with these runners raised the following error:

```
absl.flags._exceptions.UnparsedFlagAccessError: Trying to access flag --test_tmpdir before flags were parsed.
``` 

This happened because the absl flags were only being parsed when running the modules directly. With this change, flags are manually parsed and use default values if the modules aren't run directly, as is the case when using pyttest and unittest. See the [absl-py flags documentation](https://abseil.io/docs/python/guides/flags#faqs) for a more detailed explanation.

## How did you test this change?

### pytest

Ran `pytest model_card_toolkit`. Abridged summary:

```
================================== test session starts ===================================
platform darwin -- Python 3.8.13, pytest-7.2.0, pluggy-1.0.0
rootdir: /Users/sue/workspace/oss/mct-dev/model-card-toolkit
plugins: anyio-3.6.2
collected 78 items                                                                       

model_card_toolkit/core_test.py ..................                                 [ 23%]
model_card_toolkit/model_card_test.py ................                             [ 43%]
model_card_toolkit/documentation/examples/cats_vs_dogs_test.py .                   [ 44%]
model_card_toolkit/utils/graphics_test.py .........                                [ 56%]
model_card_toolkit/utils/json_util_test.py ...                                     [ 60%]
model_card_toolkit/utils/tfx_util_test.py .....................                    [ 87%]
model_card_toolkit/utils/validation_test.py .......                                [ 96%]
model_card_toolkit/utils/testdata/testdata_utils_test.py ...                       [100%]

==================================== warnings summary ====================================
../../../../.pyenv/versions/3.8.13/envs/mct-dev/lib/python3.8/site-packages/hdfs/config.py:15
  /Users/sue/.pyenv/versions/3.8.13/envs/mct-dev/lib/python3.8/site-packages/hdfs/config.py:15: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses
    from imp import load_source

../../../../.pyenv/versions/3.8.13/envs/mct-dev/lib/python3.8/site-packages/jupyter_client/connect.py:27
  /Users/sue/.pyenv/versions/3.8.13/envs/mct-dev/lib/python3.8/site-packages/jupyter_client/connect.py:27: DeprecationWarning: Jupyter is migrating its paths to use standard platformdirs
  given by the platformdirs library.  To remove this warning and
  see the appropriate new directories, set the environment variable
  `JUPYTER_PLATFORM_DIRS=1` and then run `jupyter --paths`.
  The use of platformdirs will be the default in `jupyter_core` v6
    from jupyter_core.paths import jupyter_data_dir

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================= 78 passed, 2 warnings in 83.81s (0:01:23) ========================
```

### unittest

Couldn't figure out the right pattern to discover all tests, so I only tested the problematic modules.

Ran `python -m unittest model_card_toolkit/core_test.py`:

```
Ran 18 tests in 72.494s

OK
```

Ran `python -m unittest model_card_toolkit/utils/testdata/tfxtest.py`:

```
Ran 1 test in 0.002s

OK
```

## How did you document this change?

N/A

## Before submitting

Before submitting a pull request, please be sure to do the following:
- [x] Read the [How to Contribute guide](https://github.com/tensorflow/model-card-toolkit/blob/master/CONTRIBUTING.md) if this is your first contribution.
- [x] Open an issue or discussion topic to discuss this change. (Discussed over video chat.)
- [x] Write new tests if applicable.
- [x] Update documentation if applicable.
