### PR TITLE
release 2.0 rc0

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -34,6 +34,36 @@ Current Release Team:
 - Suzen Fylke - @codesue
 
 ## Past Releases
+
+### Release 2.0.0
+
+#### Major Features and Improvements
+* Reduced package dependencies and therefore removed `tfx` as a dependency.
+
+#### Bug fixes and other changes
+* Updated `Standalone_Model_Card_Toolkit_Demo.ipynb` demo.
+* Updated linter setup.
+* Updated `tensorflow-datasets` dependency for tests.
+* Updated package release workflow.
+
+#### Breaking changes and Deprecations
+* Renamed `master` branch to `main`.
+* Deprecated `ModelCardGenerator`. The component will be made available via TFX Addons.
+
+#### Contributions By
+* Alan Schiemenz
+* Calvin Leung
+* Gerard Casas Saez
+* Hannes Hapke
+* Rebecca Chen
+* Sanat
+* Suzen Fylke
+* sklin93
+* vulkomilev
+
+Thank you!
+
+
 ### Release 1.3.2
 
 #### Major Features and Improvements

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -35,35 +35,6 @@ Current Release Team:
 
 ## Past Releases
 
-### Release 2.0.0
-
-#### Major Features and Improvements
-* Reduced package dependencies and therefore removed `tfx` as a dependency.
-
-#### Bug fixes and other changes
-* Updated `Standalone_Model_Card_Toolkit_Demo.ipynb` demo.
-* Updated linter setup.
-* Updated `tensorflow-datasets` dependency for tests.
-* Updated package release workflow.
-
-#### Breaking changes and Deprecations
-* Renamed `master` branch to `main`.
-* Deprecated `ModelCardGenerator`. The component will be made available via TFX Addons.
-
-#### Contributions By
-* Alan Schiemenz
-* Calvin Leung
-* Gerard Casas Saez
-* Hannes Hapke
-* Rebecca Chen
-* Sanat
-* Suzen Fylke
-* sklin93
-* vulkomilev
-
-Thank you!
-
-
 ### Release 1.3.2
 
 #### Major Features and Improvements

--- a/model_card_toolkit/version.py
+++ b/model_card_toolkit/version.py
@@ -23,7 +23,7 @@ _PATCH_VERSION = "0"
 # stable release (indicated by `_VERSION_SUFFIX = ''`). Outside the context of a
 # release branch, the current version is by default assumed to be a
 # 'development' version, labeled 'dev'.
-_VERSION_SUFFIX = "dev"
+_VERSION_SUFFIX = "rc0"
 
 # This produces version numbers such as, '0.1.0-dev', for example.
 __version__ = ".".join([_MAJOR_VERSION, _MINOR_VERSION, _PATCH_VERSION])


### PR DESCRIPTION
# What does this pull request do?

The PR release the MCT version 2.0 rc0, not the 2.0 production version.

