### PR TITLE
Release 2.0

### DIFF
--- a/model_card_toolkit/version.py
+++ b/model_card_toolkit/version.py
@@ -23,7 +23,7 @@ _PATCH_VERSION = "0"
 # stable release (indicated by `_VERSION_SUFFIX = ''`). Outside the context of a
 # release branch, the current version is by default assumed to be a
 # 'development' version, labeled 'dev'.
-_VERSION_SUFFIX = "rc0"
+_VERSION_SUFFIX = ""
 
 # This produces version numbers such as, '0.1.0-dev', for example.
 __version__ = ".".join([_MAJOR_VERSION, _MINOR_VERSION, _PATCH_VERSION])


### PR DESCRIPTION
# What does this pull request do?

PR to trigger a PyPI build

## How did you test this change?

### Installed the library locally

Installed in an empty Python 3.8.13 virtual environment using `pip install -i https://test.pypi.org/simple/ model-card-toolkit==2.0.0rc0 --extra-index-url https://pypi.org/simple`

<details><summary><b>Installation output</b></summary>
<br/>
<pre><code>
Looking in indexes: https://test.pypi.org/simple/, https://pypi.org/simple
Collecting model-card-toolkit==2.0.0rc0
  Downloading model_card_toolkit-2.0.0rc0-py3-none-any.whl (68 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 68.9/68.9 KB 2.1 MB/s eta 0:00:00
Collecting jinja2<3.2,>=3.1
  Using cached Jinja2-3.1.2-py3-none-any.whl (133 kB)
Collecting ml-metadata<2.0.0,>=1.5.0
  Using cached ml_metadata-1.12.0-cp38-cp38-macosx_12_0_x86_64.whl (19.2 MB)
Collecting tensorflow-data-validation<2.0.0,>=1.5.0
  Using cached tensorflow_data_validation-1.12.0-cp38-cp38-macosx_12_0_x86_64.whl (19.5 MB)
Collecting tensorflow-model-analysis<0.42.0,>=0.36.0
  Using cached tensorflow_model_analysis-0.41.1-py3-none-any.whl (1.8 MB)
Collecting absl-py<1.1,>=0.9
  Using cached absl_py-1.0.0-py3-none-any.whl (126 kB)
Collecting jsonschema<4,>=3.2.0
  Using cached jsonschema-3.2.0-py2.py3-none-any.whl (56 kB)
Collecting matplotlib<4,>=3.2.0
  Downloading matplotlib-3.7.1-cp38-cp38-macosx_10_12_x86_64.whl (7.4 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 7.4/7.4 MB 12.4 MB/s eta 0:00:00
Collecting tensorflow-metadata<2.0.0,>=1.5.0
  Using cached tensorflow_metadata-1.12.0-py3-none-any.whl (52 kB)
Collecting six
  Using cached six-1.16.0-py2.py3-none-any.whl (11 kB)
Collecting MarkupSafe>=2.0
  Downloading MarkupSafe-2.1.2-cp38-cp38-macosx_10_9_x86_64.whl (13 kB)
Requirement already satisfied: setuptools in /Users/sue/.pyenv/versions/3.8.13/envs/mct/lib/python3.8/site-packages (from jsonschema<4,>=3.2.0->model-card-toolkit==2.0.0rc0) (56.0.0)
Collecting attrs>=17.4.0
  Using cached attrs-22.2.0-py3-none-any.whl (60 kB)
Collecting pyrsistent>=0.14.0
  Downloading pyrsistent-0.19.3-cp38-cp38-macosx_10_9_universal2.whl (82 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 82.5/82.5 KB 4.2 MB/s eta 0:00:00
Collecting cycler>=0.10
  Using cached cycler-0.11.0-py3-none-any.whl (6.4 kB)
Collecting kiwisolver>=1.0.1
  Using cached kiwisolver-1.4.4-cp38-cp38-macosx_10_9_x86_64.whl (65 kB)
Collecting contourpy>=1.0.1
  Downloading contourpy-1.0.7-cp38-cp38-macosx_10_9_x86_64.whl (243 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 244.0/244.0 KB 12.1 MB/s eta 0:00:00
Collecting importlib-resources>=3.2.0
  Downloading importlib_resources-5.12.0-py3-none-any.whl (36 kB)
Collecting python-dateutil>=2.7
  Using cached python_dateutil-2.8.2-py2.py3-none-any.whl (247 kB)
Collecting pyparsing>=2.3.1
  Using cached pyparsing-3.0.9-py3-none-any.whl (98 kB)
Collecting fonttools>=4.22.0
  Downloading fonttools-4.39.3-py3-none-any.whl (1.0 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 1.0/1.0 MB 21.1 MB/s eta 0:00:00
Collecting packaging>=20.0
  Downloading packaging-23.0-py3-none-any.whl (42 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 42.7/42.7 KB 1.7 MB/s eta 0:00:00
Collecting numpy>=1.20
  Downloading numpy-1.24.2-cp38-cp38-macosx_10_9_x86_64.whl (19.8 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 19.8/19.8 MB 26.4 MB/s eta 0:00:00
Collecting pillow>=6.2.0
  Downloading Pillow-9.5.0-cp38-cp38-macosx_10_10_x86_64.whl (3.4 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 3.4/3.4 MB 25.4 MB/s eta 0:00:00
Collecting grpcio<2,>=1.8.6
  Downloading grpcio-1.53.0-cp38-cp38-macosx_10_10_universal2.whl (8.5 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 8.5/8.5 MB 26.1 MB/s eta 0:00:00
Collecting protobuf<4,>=3.13
  Using cached protobuf-3.20.3-cp38-cp38-macosx_10_9_x86_64.whl (982 kB)
Collecting attrs>=17.4.0
  Using cached attrs-21.4.0-py2.py3-none-any.whl (60 kB)
Collecting pandas<2,>=1.0
  Downloading pandas-1.5.3-cp38-cp38-macosx_10_9_x86_64.whl (11.9 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 11.9/11.9 MB 29.5 MB/s eta 0:00:00
Collecting joblib>=1.2.0
  Using cached joblib-1.2.0-py3-none-any.whl (297 kB)
Collecting pyarrow<7,>=6
  Using cached pyarrow-6.0.1-cp38-cp38-macosx_10_13_x86_64.whl (19.1 MB)
Collecting apache-beam[gcp]<3,>=2.40
  Downloading apache_beam-2.46.0-cp38-cp38-macosx_10_9_x86_64.whl (5.1 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 5.1/5.1 MB 1.8 MB/s eta 0:00:00
Collecting tensorflow<3,>=2.11
  Downloading tensorflow-2.12.0-cp38-cp38-macosx_10_15_x86_64.whl (230.1 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 230.1/230.1 MB 2.2 MB/s eta 0:00:00
Collecting pyfarmhash<0.4,>=0.2
  Using cached pyfarmhash-0.3.2-cp38-cp38-macosx_12_0_x86_64.whl
Collecting tfx-bsl<1.13,>=1.12.0
  Using cached tfx_bsl-1.12.0-cp38-cp38-macosx_12_0_x86_64.whl (23.1 MB)
Collecting googleapis-common-protos<2,>=1.52.0
  Downloading googleapis_common_protos-1.59.0-py2.py3-none-any.whl (223 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 223.6/223.6 KB 12.9 MB/s eta 0:00:00
Collecting scipy<2,>=1.4.1
  Downloading scipy-1.10.1-cp38-cp38-macosx_10_9_x86_64.whl (35.0 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 35.0/35.0 MB 23.8 MB/s eta 0:00:00
Collecting tensorflow-model-analysis<0.42.0,>=0.36.0
  Using cached tensorflow_model_analysis-0.41.0-py3-none-any.whl (1.8 MB)
  Using cached tensorflow_model_analysis-0.40.0-py3-none-any.whl (1.8 MB)
  Using cached tensorflow_model_analysis-0.39.0-py3-none-any.whl (1.8 MB)
  Using cached tensorflow_model_analysis-0.38.0-py3-none-any.whl (1.8 MB)
  Using cached tensorflow_model_analysis-0.37.0-py3-none-any.whl (1.8 MB)
  Using cached tensorflow_model_analysis-0.36.0-py3-none-any.whl (1.8 MB)
Collecting absl-py<1.1,>=0.9
  Using cached absl_py-0.12.0-py3-none-any.whl (129 kB)
INFO: pip is looking at multiple versions of tensorflow-metadata to determine which version is compatible with other requirements. This could take a while.
INFO: pip is looking at multiple versions of tensorflow-data-validation to determine which version is compatible with other requirements. This could take a while.
Collecting tensorflow-data-validation<2.0.0,>=1.5.0
  Using cached tensorflow_data_validation-1.11.0-cp38-cp38-macosx_10_9_x86_64.whl (19.2 MB)
Collecting tensorflow-metadata<2.0.0,>=1.5.0
  Using cached tensorflow_metadata-1.11.0-py3-none-any.whl (52 kB)
Collecting tfx-bsl<1.12,>=1.11.0
  Using cached tfx_bsl-1.11.0-cp38-cp38-macosx_10_9_x86_64.whl (22.9 MB)
Collecting tensorflow-data-validation<2.0.0,>=1.5.0
  Using cached tensorflow_data_validation-1.10.0-cp38-cp38-macosx_10_9_x86_64.whl (1.7 MB)
Collecting tfx-bsl<1.11,>=1.10.1
  Using cached tfx_bsl-1.10.1-cp38-cp38-macosx_10_9_x86_64.whl (22.9 MB)
Collecting joblib<0.15,>=0.12
  Using cached joblib-0.14.1-py2.py3-none-any.whl (294 kB)
Collecting tensorflow-metadata<2.0.0,>=1.5.0
  Using cached tensorflow_metadata-1.10.0-py3-none-any.whl (50 kB)
Collecting ipython<8,>=7
  Using cached ipython-7.34.0-py3-none-any.whl (793 kB)
Collecting ipywidgets<8,>=7
  Downloading ipywidgets-7.7.5-py2.py3-none-any.whl (123 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 123.9/123.9 KB 6.1 MB/s eta 0:00:00
Collecting tensorflow-serving-api!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,!=2.8.*,<3,>=1.15
  Downloading tensorflow_serving_api-2.11.1-py2.py3-none-any.whl (37 kB)
Collecting google-api-python-client<2,>=1.7.11
  Using cached google_api_python_client-1.12.11-py2.py3-none-any.whl (62 kB)
Collecting orjson<4.0
  Downloading orjson-3.8.9-cp38-cp38-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl (488 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 488.4/488.4 KB 23.5 MB/s eta 0:00:00
Collecting proto-plus<2,>=1.7.1
  Downloading proto_plus-1.22.2-py3-none-any.whl (47 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 47.9/47.9 KB 2.3 MB/s eta 0:00:00
Collecting fastavro<2,>=0.23.6
  Downloading fastavro-1.7.3-cp38-cp38-macosx_10_15_x86_64.whl (526 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 526.1/526.1 KB 24.9 MB/s eta 0:00:00
Collecting pytz>=2018.3
  Downloading pytz-2023.3-py2.py3-none-any.whl (502 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 502.3/502.3 KB 18.0 MB/s eta 0:00:00
Collecting cloudpickle~=2.2.1
  Downloading cloudpickle-2.2.1-py3-none-any.whl (25 kB)
Collecting pymongo<4.0.0,>=3.8.0
  Using cached pymongo-3.13.0-cp38-cp38-macosx_10_9_x86_64.whl (395 kB)
Collecting fasteners<1.0,>=0.3
  Using cached fasteners-0.18-py3-none-any.whl (18 kB)
Collecting dill<0.3.2,>=0.3.1.1
  Using cached dill-0.3.1.1-py3-none-any.whl
Collecting httplib2<0.22.0,>=0.8
  Downloading httplib2-0.21.0-py3-none-any.whl (96 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 96.8/96.8 KB 4.8 MB/s eta 0:00:00
Collecting regex>=2020.6.8
  Downloading regex-2023.3.23-cp38-cp38-macosx_10_9_x86_64.whl (294 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 294.5/294.5 KB 12.1 MB/s eta 0:00:00
Collecting objsize<0.7.0,>=0.6.1
  Downloading objsize-0.6.1-py3-none-any.whl (9.3 kB)
Collecting pydot<2,>=1.2.0
  Using cached pydot-1.4.2-py2.py3-none-any.whl (21 kB)
Collecting hdfs<3.0.0,>=2.1.0
  Using cached hdfs-2.7.0-py3-none-any.whl (34 kB)
Collecting crcmod<2.0,>=1.7
  Using cached crcmod-1.7-cp38-cp38-macosx_12_0_x86_64.whl
Collecting requests<3.0.0,>=2.24.0
  Downloading requests-2.28.2-py3-none-any.whl (62 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 62.8/62.8 KB 3.7 MB/s eta 0:00:00
Collecting typing-extensions>=3.7.0
  Downloading typing_extensions-4.5.0-py3-none-any.whl (27 kB)
Collecting zstandard<1,>=0.18.0
  Downloading zstandard-0.20.0-cp38-cp38-macosx_10_9_x86_64.whl (455 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 456.0/456.0 KB 22.0 MB/s eta 0:00:00
Collecting google-cloud-pubsublite<2,>=1.2.0
  Downloading google_cloud_pubsublite-1.8.1-py2.py3-none-any.whl (288 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 288.1/288.1 KB 12.9 MB/s eta 0:00:00
Collecting google-cloud-bigquery<4,>=1.6.0
  Downloading google_cloud_bigquery-3.9.0-py2.py3-none-any.whl (217 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 217.3/217.3 KB 9.5 MB/s eta 0:00:00
Collecting google-cloud-datastore<2,>=1.8.0
  Using cached google_cloud_datastore-1.15.5-py2.py3-none-any.whl (134 kB)
Collecting google-cloud-dlp<4,>=3.0.0
  Downloading google_cloud_dlp-3.12.1-py2.py3-none-any.whl (143 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 143.4/143.4 KB 7.3 MB/s eta 0:00:00
Collecting google-apitools<0.5.32,>=0.5.31
  Using cached google_apitools-0.5.31-py3-none-any.whl
Collecting google-cloud-spanner<4,>=3.0.0
  Downloading google_cloud_spanner-3.29.0-py2.py3-none-any.whl (327 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 327.3/327.3 KB 14.1 MB/s eta 0:00:00
Collecting google-cloud-recommendations-ai<0.8.0,>=0.1.0
  Using cached google_cloud_recommendations_ai-0.7.1-py2.py3-none-any.whl (148 kB)
Collecting cachetools<5,>=3.1.0
  Using cached cachetools-4.2.4-py3-none-any.whl (10 kB)
Collecting google-cloud-bigquery-storage<2.17,>=2.6.3
  Downloading google_cloud_bigquery_storage-2.16.2-py2.py3-none-any.whl (185 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 185.4/185.4 KB 8.7 MB/s eta 0:00:00
Collecting google-cloud-core<3,>=0.28.1
  Using cached google_cloud_core-2.3.2-py2.py3-none-any.whl (29 kB)
Collecting google-cloud-videointelligence<2,>=1.8.0
  Using cached google_cloud_videointelligence-1.16.3-py2.py3-none-any.whl (183 kB)
Collecting google-auth-httplib2<0.2.0,>=0.1.0
  Using cached google_auth_httplib2-0.1.0-py2.py3-none-any.whl (9.3 kB)
Collecting google-cloud-bigtable<2,>=0.31.1
  Using cached google_cloud_bigtable-1.7.3-py2.py3-none-any.whl (268 kB)
Collecting google-auth<3,>=1.18.0
  Downloading google_auth-2.17.1-py2.py3-none-any.whl (178 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 178.1/178.1 KB 9.4 MB/s eta 0:00:00
Collecting google-cloud-language<2,>=1.3.0
  Using cached google_cloud_language-1.3.2-py2.py3-none-any.whl (83 kB)
Collecting google-cloud-pubsub<3,>=2.1.0
  Downloading google_cloud_pubsub-2.15.2-py2.py3-none-any.whl (243 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 243.1/243.1 KB 10.2 MB/s eta 0:00:00
Collecting google-cloud-vision<4,>=2
  Downloading google_cloud_vision-3.4.1-py2.py3-none-any.whl (444 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 444.3/444.3 KB 18.7 MB/s eta 0:00:00
Collecting zipp>=3.1.0
  Downloading zipp-3.15.0-py3-none-any.whl (6.8 kB)
Collecting pygments
  Downloading Pygments-2.14.0-py3-none-any.whl (1.1 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 1.1/1.1 MB 21.6 MB/s eta 0:00:00
Collecting pexpect>4.3
  Using cached pexpect-4.8.0-py2.py3-none-any.whl (59 kB)
Collecting backcall
  Using cached backcall-0.2.0-py2.py3-none-any.whl (11 kB)
Collecting decorator
  Using cached decorator-5.1.1-py3-none-any.whl (9.1 kB)
Collecting pickleshare
  Using cached pickleshare-0.7.5-py2.py3-none-any.whl (6.9 kB)
Collecting matplotlib-inline
  Using cached matplotlib_inline-0.1.6-py3-none-any.whl (9.4 kB)
Collecting appnope
  Using cached appnope-0.1.3-py2.py3-none-any.whl (4.4 kB)
Collecting prompt-toolkit!=3.0.0,!=3.0.1,<3.1.0,>=2.0.0
  Downloading prompt_toolkit-3.0.38-py3-none-any.whl (385 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 385.8/385.8 KB 19.9 MB/s eta 0:00:00
Collecting traitlets>=4.2
  Downloading traitlets-5.9.0-py3-none-any.whl (117 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 117.4/117.4 KB 6.6 MB/s eta 0:00:00
Collecting jedi>=0.16
  Using cached jedi-0.18.2-py2.py3-none-any.whl (1.6 MB)
Collecting jupyterlab-widgets<3,>=1.0.0
  Downloading jupyterlab_widgets-1.1.4-py3-none-any.whl (246 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 246.1/246.1 KB 8.8 MB/s eta 0:00:00
Collecting widgetsnbextension~=3.6.4
  Downloading widgetsnbextension-3.6.4-py2.py3-none-any.whl (1.6 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 1.6/1.6 MB 5.9 MB/s eta 0:00:00
Collecting ipython-genutils~=0.2.0
  Using cached ipython_genutils-0.2.0-py2.py3-none-any.whl (26 kB)
Collecting ipykernel>=4.5.1
  Downloading ipykernel-6.22.0-py3-none-any.whl (149 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 150.0/150.0 KB 5.2 MB/s eta 0:00:00
Collecting termcolor>=1.1.0
  Downloading termcolor-2.2.0-py3-none-any.whl (6.6 kB)
Collecting opt-einsum>=2.3.2
  Using cached opt_einsum-3.3.0-py3-none-any.whl (65 kB)
Collecting wrapt<1.15,>=1.11.0
  Using cached wrapt-1.14.1-cp38-cp38-macosx_10_9_x86_64.whl (35 kB)
Collecting tensorflow-io-gcs-filesystem>=0.23.1
  Downloading tensorflow_io_gcs_filesystem-0.32.0-cp38-cp38-macosx_10_14_x86_64.whl (1.7 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 1.7/1.7 MB 20.5 MB/s eta 0:00:00
Collecting libclang>=13.0.0
  Downloading libclang-16.0.0-py2.py3-none-macosx_10_9_x86_64.whl (26.7 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 26.7/26.7 MB 25.9 MB/s eta 0:00:00
Collecting astunparse>=1.6.0
  Using cached astunparse-1.6.3-py2.py3-none-any.whl (12 kB)
Collecting gast<=0.4.0,>=0.2.1
  Using cached gast-0.4.0-py3-none-any.whl (9.8 kB)
Collecting numpy>=1.20
  Using cached numpy-1.23.5-cp38-cp38-macosx_10_9_x86_64.whl (18.1 MB)
Collecting tensorflow-estimator<2.13,>=2.12.0
  Downloading tensorflow_estimator-2.12.0-py2.py3-none-any.whl (440 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 440.7/440.7 KB 17.7 MB/s eta 0:00:00
Collecting google-pasta>=0.1.1
  Using cached google_pasta-0.2.0-py3-none-any.whl (57 kB)
Collecting h5py>=2.9.0
  Downloading h5py-3.8.0-cp38-cp38-macosx_10_9_x86_64.whl (3.2 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 3.2/3.2 MB 22.1 MB/s eta 0:00:00
Collecting keras<2.13,>=2.12.0
  Downloading keras-2.12.0-py2.py3-none-any.whl (1.7 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 1.7/1.7 MB 23.2 MB/s eta 0:00:00
Collecting jax>=0.3.15
  Downloading jax-0.4.8.tar.gz (1.2 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 1.2/1.2 MB 24.3 MB/s eta 0:00:00
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done
Collecting tensorboard<2.13,>=2.12
  Downloading tensorboard-2.12.1-py3-none-any.whl (5.6 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 5.6/5.6 MB 28.2 MB/s eta 0:00:00
Collecting flatbuffers>=2.0
  Downloading flatbuffers-23.3.3-py2.py3-none-any.whl (26 kB)
Collecting wheel<1.0,>=0.23.0
  Using cached wheel-0.40.0-py3-none-any.whl (64 kB)
Collecting uritemplate<4dev,>=3.0.0
  Using cached uritemplate-3.0.1-py2.py3-none-any.whl (15 kB)
Collecting google-api-core<3dev,>=1.21.0
  Using cached google_api_core-2.11.0-py3-none-any.whl (120 kB)
Collecting oauth2client>=1.4.12
  Using cached oauth2client-4.1.3-py2.py3-none-any.whl (98 kB)
Collecting pyasn1-modules>=0.2.1
  Using cached pyasn1_modules-0.2.8-py2.py3-none-any.whl (155 kB)
Collecting rsa<5,>=3.1.4
  Using cached rsa-4.9-py3-none-any.whl (34 kB)
Collecting google-resumable-media<3.0dev,>=0.6.0
  Downloading google_resumable_media-2.4.1-py2.py3-none-any.whl (77 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 77.7/77.7 KB 3.9 MB/s eta 0:00:00
Collecting grpc-google-iam-v1<0.13dev,>=0.12.3
  Downloading grpc_google_iam_v1-0.12.6-py2.py3-none-any.whl (26 kB)
Collecting grpcio-status>=1.33.2
  Downloading grpcio_status-1.53.0-py3-none-any.whl (5.1 kB)
Collecting overrides<7.0.0,>=6.0.1
  Using cached overrides-6.5.0-py3-none-any.whl (17 kB)
Collecting sqlparse>=0.3.0
  Using cached sqlparse-0.4.3-py3-none-any.whl (42 kB)
Collecting docopt
  Using cached https://test-files.pythonhosted.org/packages/f9/d7/d8f8d3e2d51df48c181d8e3706396c6fc2759b120b6be06721f00d84fe94/docopt-0.6.2-py2.py3-none-any.whl (19 kB)
Collecting nest-asyncio
  Using cached nest_asyncio-1.5.6-py3-none-any.whl (5.2 kB)
Collecting tornado>=6.1
  Using cached tornado-6.2-cp37-abi3-macosx_10_9_x86_64.whl (419 kB)
Collecting jupyter-core!=5.0.*,>=4.12
  Downloading jupyter_core-5.3.0-py3-none-any.whl (93 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 93.2/93.2 KB 3.7 MB/s eta 0:00:00
Collecting debugpy>=1.6.5
  Downloading debugpy-1.6.6-cp38-cp38-macosx_10_15_x86_64.whl (1.7 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 1.7/1.7 MB 27.5 MB/s eta 0:00:00
Collecting pyzmq>=20
  Downloading pyzmq-25.0.2-cp38-cp38-macosx_10_15_universal2.whl (1.8 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 1.8/1.8 MB 26.0 MB/s eta 0:00:00
Collecting comm>=0.1.1
  Downloading comm-0.1.3-py3-none-any.whl (6.6 kB)
Collecting jupyter-client>=6.1.12
  Downloading jupyter_client-8.1.0-py3-none-any.whl (102 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 102.9/102.9 KB 4.5 MB/s eta 0:00:00
Collecting psutil
  Using cached psutil-5.9.4-cp36-abi3-macosx_10_9_x86_64.whl (243 kB)
Collecting ml-dtypes>=0.0.3
  Downloading ml_dtypes-0.0.4-cp38-cp38-macosx_10_9_universal2.whl (226 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 226.2/226.2 KB 11.5 MB/s eta 0:00:00
Collecting parso<0.9.0,>=0.8.0
  Using cached parso-0.8.3-py2.py3-none-any.whl (100 kB)
Collecting ptyprocess>=0.5
  Using cached ptyprocess-0.7.0-py2.py3-none-any.whl (13 kB)
Collecting wcwidth
  Downloading wcwidth-0.2.6-py2.py3-none-any.whl (29 kB)
Collecting charset-normalizer<4,>=2
  Downloading charset_normalizer-3.1.0-cp38-cp38-macosx_10_9_x86_64.whl (123 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 123.4/123.4 KB 7.1 MB/s eta 0:00:00
Collecting urllib3<1.27,>=1.21.1
  Downloading urllib3-1.26.15-py2.py3-none-any.whl (140 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 140.9/140.9 KB 7.4 MB/s eta 0:00:00
Collecting certifi>=2017.4.17
  Using cached certifi-2022.12.7-py3-none-any.whl (155 kB)
Collecting idna<4,>=2.5
  Using cached idna-3.4-py3-none-any.whl (61 kB)
Collecting markdown>=2.6.8
  Downloading Markdown-3.4.3-py3-none-any.whl (93 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 93.9/93.9 KB 6.2 MB/s eta 0:00:00
Collecting tensorboard-plugin-wit>=1.6.0
  Using cached tensorboard_plugin_wit-1.8.1-py3-none-any.whl (781 kB)
Collecting google-auth-oauthlib<1.1,>=0.5
  Downloading google_auth_oauthlib-1.0.0-py2.py3-none-any.whl (18 kB)
Collecting tensorboard-data-server<0.8.0,>=0.7.0
  Downloading tensorboard_data_server-0.7.0-py3-none-macosx_10_9_x86_64.whl (4.8 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 4.8/4.8 MB 30.0 MB/s eta 0:00:00
Collecting werkzeug>=1.0.1
  Downloading Werkzeug-2.2.3-py3-none-any.whl (233 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 233.6/233.6 KB 12.5 MB/s eta 0:00:00
Collecting tensorflow-serving-api!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,!=2.8.*,<3,>=1.15
  Using cached tensorflow_serving_api-2.11.0-py2.py3-none-any.whl (37 kB)
  Using cached tensorflow_serving_api-2.10.1-py2.py3-none-any.whl (37 kB)
Collecting notebook>=4.4.1
  Downloading notebook-6.5.3-py3-none-any.whl (529 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 529.7/529.7 KB 21.6 MB/s eta 0:00:00
Collecting requests-oauthlib>=0.7.0
  Using cached requests_oauthlib-1.3.1-py2.py3-none-any.whl (23 kB)
Collecting google-crc32c<2.0dev,>=1.0
  Using cached google_crc32c-1.5.0-cp38-cp38-macosx_10_9_x86_64.whl (30 kB)
Collecting grpcio-status>=1.33.2
  Downloading grpcio_status-1.51.3-py3-none-any.whl (5.1 kB)
  Using cached grpcio_status-1.51.1-py3-none-any.whl (5.1 kB)
  Using cached grpcio_status-1.50.0-py3-none-any.whl (14 kB)
  Using cached grpcio_status-1.49.1-py3-none-any.whl (14 kB)
  Using cached grpcio_status-1.48.2-py3-none-any.whl (14 kB)
Collecting importlib-metadata>=4.8.3
  Downloading importlib_metadata-6.1.0-py3-none-any.whl (21 kB)
Collecting platformdirs>=2.5
  Downloading platformdirs-3.2.0-py3-none-any.whl (14 kB)
Collecting Send2Trash>=1.8.0
  Using cached Send2Trash-1.8.0-py3-none-any.whl (18 kB)
Collecting nbformat
  Downloading nbformat-5.8.0-py3-none-any.whl (77 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 77.4/77.4 KB 3.4 MB/s eta 0:00:00
Collecting prometheus-client
  Downloading prometheus_client-0.16.0-py3-none-any.whl (122 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 122.5/122.5 KB 7.6 MB/s eta 0:00:00
Collecting argon2-cffi
  Using cached argon2_cffi-21.3.0-py3-none-any.whl (14 kB)
Collecting nbconvert>=5
  Downloading nbconvert-7.2.10-py3-none-any.whl (275 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 275.2/275.2 KB 15.4 MB/s eta 0:00:00
Collecting terminado>=0.8.3
  Using cached terminado-0.17.1-py3-none-any.whl (17 kB)
Collecting nbclassic>=0.4.7
  Downloading nbclassic-0.5.4-py3-none-any.whl (10.0 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 10.0/10.0 MB 30.7 MB/s eta 0:00:00
Collecting pyasn1>=0.1.7
  Using cached pyasn1-0.4.8-py2.py3-none-any.whl (77 kB)
Collecting jupyter-server>=1.8
  Using cached https://test-files.pythonhosted.org/packages/db/48/6aad0d884797c1d6eb02a92cdd8b19bd8d1d650638823869dfacaefd5062/jupyter_server-100.100.1-py3-none-any.whl (377 kB)
Collecting notebook-shim>=0.1.0
  Using cached notebook_shim-0.2.2-py3-none-any.whl (13 kB)
Collecting pandocfilters>=1.4.1
  Using cached pandocfilters-1.5.0-py2.py3-none-any.whl (8.7 kB)
Collecting mistune<3,>=2.0.3
  Downloading mistune-2.0.5-py2.py3-none-any.whl (24 kB)
Collecting tinycss2
  Using cached tinycss2-1.2.1-py3-none-any.whl (21 kB)
Collecting nbclient>=0.5.0
  Using cached nbclient-0.7.2-py3-none-any.whl (71 kB)
Collecting bleach
  Downloading bleach-6.0.0-py3-none-any.whl (162 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 162.5/162.5 KB 8.9 MB/s eta 0:00:00
Collecting defusedxml
  Using cached defusedxml-0.7.1-py2.py3-none-any.whl (25 kB)
Collecting beautifulsoup4
  Downloading beautifulsoup4-4.12.0-py3-none-any.whl (132 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 132.2/132.2 KB 5.7 MB/s eta 0:00:00
Collecting jupyterlab-pygments
  Using cached jupyterlab_pygments-0.2.2-py2.py3-none-any.whl (21 kB)
Collecting fastjsonschema
  Downloading fastjsonschema-2.16.3-py3-none-any.whl (23 kB)
Collecting oauthlib>=3.0.0
  Using cached oauthlib-3.2.2-py3-none-any.whl (151 kB)
Collecting argon2-cffi-bindings
  Using cached argon2_cffi_bindings-21.2.0-cp38-abi3-macosx_10_9_universal2.whl (53 kB)
Collecting jupyter-packaging~=0.9
  Using cached jupyter_packaging-0.12.3-py3-none-any.whl (15 kB)
Collecting anyio<3,>=2.0.2
  Using cached anyio-2.2.0-py3-none-any.whl (65 kB)
Collecting jupyter-server>=1.8
  Downloading jupyter_server-2.5.0-py3-none-any.whl (366 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 366.8/366.8 KB 17.2 MB/s eta 0:00:00
Collecting websocket-client
  Downloading websocket_client-1.5.1-py3-none-any.whl (55 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 55.9/55.9 KB 2.9 MB/s eta 0:00:00
Collecting jupyter-server-terminals
  Downloading jupyter_server_terminals-0.4.4-py3-none-any.whl (13 kB)
Collecting jupyter-server>=1.8
  Downloading jupyter_server-2.4.0-py3-none-any.whl (366 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 366.7/366.7 KB 15.2 MB/s eta 0:00:00
  Downloading jupyter_server-2.3.0-py3-none-any.whl (365 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 365.8/365.8 KB 21.0 MB/s eta 0:00:00
  Downloading jupyter_server-2.2.1-py3-none-any.whl (365 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 365.3/365.3 KB 17.7 MB/s eta 0:00:00
  Downloading jupyter_server-2.2.0-py3-none-any.whl (365 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 365.2/365.2 KB 17.1 MB/s eta 0:00:00
  Downloading jupyter_server-2.1.0-py3-none-any.whl (365 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 365.2/365.2 KB 18.4 MB/s eta 0:00:00
  Downloading jupyter_server-2.0.6-py3-none-any.whl (363 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 364.0/364.0 KB 17.4 MB/s eta 0:00:00
  Downloading jupyter_server-2.0.5-py3-none-any.whl (361 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 361.1/361.1 KB 18.0 MB/s eta 0:00:00
  Using cached jupyter_server-2.0.4-py3-none-any.whl (361 kB)
  Downloading jupyter_server-2.0.3-py3-none-any.whl (361 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 361.0/361.0 KB 20.0 MB/s eta 0:00:00
  Downloading jupyter_server-2.0.2-py3-none-any.whl (360 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 360.9/360.9 KB 18.3 MB/s eta 0:00:00
  Using cached jupyter_server-2.0.1-py3-none-any.whl (360 kB)
  Downloading jupyter_server-1.23.6-py3-none-any.whl (347 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 347.4/347.4 KB 17.5 MB/s eta 0:00:00
  Downloading jupyter_server-1.23.5-py3-none-any.whl (346 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 347.0/347.0 KB 16.9 MB/s eta 0:00:00
  Downloading jupyter_server-1.23.4-py3-none-any.whl (346 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 346.8/346.8 KB 18.5 MB/s eta 0:00:00
  Using cached jupyter_server-1.23.3-py3-none-any.whl (346 kB)
  Using cached jupyter_server-1.23.2-py3-none-any.whl (346 kB)
  Using cached jupyter_server-1.23.1-py3-none-any.whl (346 kB)
  Using cached jupyter_server-1.23.0-py3-none-any.whl (346 kB)
  Using cached jupyter_server-1.21.0-py3-none-any.whl (346 kB)
  Using cached jupyter_server-1.19.1-py3-none-any.whl (346 kB)
  Using cached jupyter_server-1.19.0-py3-none-any.whl (346 kB)
  Using cached jupyter_server-1.18.1-py3-none-any.whl (344 kB)
  Using cached jupyter_server-1.18.0-py3-none-any.whl (344 kB)
  Using cached jupyter_server-1.17.1-py3-none-any.whl (344 kB)
  Using cached jupyter_server-1.17.0-py3-none-any.whl (342 kB)
  Using cached jupyter_server-1.16.0-py3-none-any.whl (343 kB)
  Using cached jupyter_server-1.15.6-py3-none-any.whl (341 kB)
  Using cached jupyter_server-1.15.5-py3-none-any.whl (341 kB)
  Using cached jupyter_server-1.15.4-py3-none-any.whl (341 kB)
  Using cached jupyter_server-1.15.3-py3-none-any.whl (341 kB)
  Using cached jupyter_server-1.15.2-py3-none-any.whl (340 kB)
  Using cached jupyter_server-1.15.1-py3-none-any.whl (339 kB)
  Using cached jupyter_server-1.15.0-py3-none-any.whl (339 kB)
  Using cached jupyter_server-1.13.5-py3-none-any.whl (397 kB)
  Using cached jupyter_server-1.13.4-py3-none-any.whl (395 kB)
  Using cached jupyter_server-1.13.3-py3-none-any.whl (395 kB)
  Using cached jupyter_server-1.13.2-py3-none-any.whl (395 kB)
  Using cached jupyter_server-1.13.1-py3-none-any.whl (396 kB)
  Using cached jupyter_server-1.13.0-py3-none-any.whl (396 kB)
  Using cached jupyter_server-1.12.1-py3-none-any.whl (395 kB)
  Using cached jupyter_server-1.12.0-py3-none-any.whl (395 kB)
  Using cached jupyter_server-1.11.2-py3-none-any.whl (394 kB)
  Using cached jupyter_server-1.11.1-py3-none-any.whl (393 kB)
  Using cached jupyter_server-1.11.0-py3-none-any.whl (393 kB)
  Using cached jupyter_server-1.10.2-py3-none-any.whl (392 kB)
  Using cached jupyter_server-1.10.1-py3-none-any.whl (392 kB)
  Using cached jupyter_server-1.10.0-py3-none-any.whl (392 kB)
  Using cached jupyter_server-1.9.0-py3-none-any.whl (389 kB)
  Using cached jupyter_server-1.8.0-py3-none-any.whl (382 kB)
INFO: pip is looking at multiple versions of notebook-shim to determine which version is compatible with other requirements. This could take a while.
Collecting notebook-shim>=0.1.0
  Using cached notebook_shim-0.2.0-py3-none-any.whl (13 kB)
Collecting sniffio>=1.1
  Using cached sniffio-1.3.0-py3-none-any.whl (10 kB)
Collecting notebook-shim>=0.1.0
  Using cached notebook_shim-0.1.0-py3-none-any.whl (13 kB)
INFO: pip is looking at multiple versions of anyio to determine which version is compatible with other requirements. This could take a while.
Collecting anyio<3,>=2.0.2
  Using cached anyio-2.1.0-py3-none-any.whl (64 kB)
  Using cached anyio-2.0.2-py3-none-any.whl (62 kB)
INFO: pip is looking at multiple versions of nbclient to determine which version is compatible with other requirements. This could take a while.
Collecting nbclient>=0.5.0
  Downloading nbclient-0.7.1-py3-none-any.whl (71 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 71.9/71.9 KB 2.8 MB/s eta 0:00:00
INFO: pip is looking at multiple versions of notebook-shim to determine which version is compatible with other requirements. This could take a while.
  Using cached nbclient-0.7.0-py3-none-any.whl (71 kB)
INFO: This is taking longer than usual. You might need to provide the dependency resolver with stricter constraints to reduce runtime. See https://pip.pypa.io/warnings/backtracking for guidance. If you want to abort this run, press Ctrl + C.
  Using cached nbclient-0.6.8-py3-none-any.whl (71 kB)
  Using cached nbclient-0.6.7-py3-none-any.whl (71 kB)
  Using cached nbclient-0.6.6-py3-none-any.whl (71 kB)
  Using cached nbclient-0.6.5-py3-none-any.whl (71 kB)
  Using cached nbclient-0.6.4-py3-none-any.whl (71 kB)
INFO: pip is looking at multiple versions of nbclient to determine which version is compatible with other requirements. This could take a while.
  Using cached nbclient-0.6.3-py3-none-any.whl (71 kB)
  Using cached nbclient-0.6.2-py3-none-any.whl (71 kB)
  Using cached nbclient-0.6.1-py3-none-any.whl (71 kB)
  Using cached nbclient-0.6.0-py3-none-any.whl (70 kB)
  Using cached nbclient-0.5.13-py3-none-any.whl (70 kB)
INFO: This is taking longer than usual. You might need to provide the dependency resolver with stricter constraints to reduce runtime. See https://pip.pypa.io/warnings/backtracking for guidance. If you want to abort this run, press Ctrl + C.
  Using cached nbclient-0.5.12-py3-none-any.whl (71 kB)
  Using cached nbclient-0.5.11-py3-none-any.whl (71 kB)
  Using cached nbclient-0.5.10-py3-none-any.whl (69 kB)
  Using cached nbclient-0.5.9-py3-none-any.whl (69 kB)
  Using cached nbclient-0.5.5-py3-none-any.whl (69 kB)
  Using cached nbclient-0.5.4-py3-none-any.whl (66 kB)
  Using cached nbclient-0.5.3-py3-none-any.whl (82 kB)
Collecting async-generator
  Using cached async_generator-1.10-py3-none-any.whl (18 kB)
Collecting nbclient>=0.5.0
  Using cached nbclient-0.5.2-py3-none-any.whl (65 kB)
  Using cached nbclient-0.5.1-py3-none-any.whl (65 kB)
  Using cached nbclient-0.5.0-py3-none-any.whl (65 kB)
INFO: pip is looking at multiple versions of mistune to determine which version is compatible with other requirements. This could take a while.
Collecting mistune<3,>=2.0.3
  Using cached mistune-2.0.4-py2.py3-none-any.whl (24 kB)
  Using cached mistune-2.0.3-py2.py3-none-any.whl (24 kB)
INFO: pip is looking at multiple versions of anyio to determine which version is compatible with other requirements. This could take a while.
INFO: pip is looking at multiple versions of jupyter-server to determine which version is compatible with other requirements. This could take a while.
Collecting jupyter-server>=1.8
  Using cached https://test-files.pythonhosted.org/packages/b0/c3/38b2a06b1754e7c7edd6301d5b366c2d1475492cbfef8933bd4bb426be6e/jupyter_server-100.5.1-py3-none-any.whl (241 kB)
Collecting anyio>=2.0.2
  Using cached anyio-3.6.2-py3-none-any.whl (80 kB)
Collecting jupyter-events>=0.4.0
  Downloading jupyter_events-0.6.3-py3-none-any.whl (18 kB)
Collecting cffi>=1.0.1
  Using cached cffi-1.15.1-cp38-cp38-macosx_10_9_x86_64.whl (178 kB)
Collecting soupsieve>1.2
  Downloading soupsieve-2.4-py3-none-any.whl (37 kB)
Collecting webencodings
  Using cached webencodings-0.5.1-py2.py3-none-any.whl (11 kB)
Collecting pycparser
  Using cached pycparser-2.21-py2.py3-none-any.whl (118 kB)
Collecting pyyaml>=5.3
  Using cached PyYAML-6.0-cp38-cp38-macosx_10_9_x86_64.whl (192 kB)
Collecting rfc3339-validator
  Downloading rfc3339_validator-0.1.4-py2.py3-none-any.whl (3.5 kB)
Collecting rfc3986-validator>=0.1.1
  Downloading rfc3986_validator-0.1.1-py2.py3-none-any.whl (4.2 kB)
Collecting python-json-logger>=2.0.4
  Downloading python_json_logger-2.0.7-py3-none-any.whl (8.1 kB)
Collecting jsonschema[format-nongpl]>=3.2.0
  Using cached jsonschema-4.17.3-py3-none-any.whl (90 kB)
  Using cached jsonschema-4.17.1-py3-none-any.whl (90 kB)
  Using cached jsonschema-4.17.0-py3-none-any.whl (83 kB)
  Using cached jsonschema-4.16.0-py3-none-any.whl (83 kB)
  Using cached jsonschema-4.15.0-py3-none-any.whl (82 kB)
  Using cached jsonschema-4.14.0-py3-none-any.whl (82 kB)
  Using cached jsonschema-4.13.0-py3-none-any.whl (81 kB)
  Using cached jsonschema-4.12.1-py3-none-any.whl (81 kB)
  Using cached jsonschema-4.12.0-py3-none-any.whl (81 kB)
  Using cached jsonschema-4.11.0-py3-none-any.whl (80 kB)
  Using cached jsonschema-4.10.3-py3-none-any.whl (81 kB)
  Using cached jsonschema-4.10.2-py3-none-any.whl (81 kB)
  Using cached jsonschema-4.10.1-py3-none-any.whl (81 kB)
  Using cached jsonschema-4.10.0-py3-none-any.whl (80 kB)
  Using cached jsonschema-4.9.1-py3-none-any.whl (79 kB)
  Using cached jsonschema-4.9.0-py3-none-any.whl (79 kB)
  Using cached jsonschema-4.8.0-py3-none-any.whl (81 kB)
  Using cached jsonschema-4.7.2-py3-none-any.whl (81 kB)
  Using cached jsonschema-4.7.1-py3-none-any.whl (80 kB)
  Using cached jsonschema-4.7.0-py3-none-any.whl (80 kB)
  Using cached jsonschema-4.6.2-py3-none-any.whl (80 kB)
  Using cached jsonschema-4.6.1-py3-none-any.whl (80 kB)
  Using cached jsonschema-4.6.0-py3-none-any.whl (80 kB)
  Using cached jsonschema-4.5.1-py3-none-any.whl (72 kB)
WARNING: jsonschema 4.5.1 does not provide the extra 'format-nongpl'
  Using cached jsonschema-4.5.0-py3-none-any.whl (73 kB)
WARNING: jsonschema 4.5.0 does not provide the extra 'format-nongpl'
  Using cached jsonschema-4.4.0-py3-none-any.whl (72 kB)
WARNING: jsonschema 4.4.0 does not provide the extra 'format-nongpl'
  Using cached jsonschema-4.3.3-py3-none-any.whl (71 kB)
WARNING: jsonschema 4.3.3 does not provide the extra 'format-nongpl'
  Using cached jsonschema-4.3.2-py3-none-any.whl (71 kB)
WARNING: jsonschema 4.3.2 does not provide the extra 'format-nongpl'
  Using cached jsonschema-4.3.1-py3-none-any.whl (71 kB)
WARNING: jsonschema 4.3.1 does not provide the extra 'format-nongpl'
  Using cached jsonschema-4.3.0-py3-none-any.whl (71 kB)
WARNING: jsonschema 4.3.0 does not provide the extra 'format-nongpl'
  Using cached jsonschema-4.2.1-py3-none-any.whl (69 kB)
WARNING: jsonschema 4.2.1 does not provide the extra 'format-nongpl'
  Downloading jsonschema-4.2.0-py3-none-any.whl (69 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 69.4/69.4 KB 3.9 MB/s eta 0:00:00
WARNING: jsonschema 4.2.0 does not provide the extra 'format-nongpl'
  Downloading jsonschema-4.1.2-py3-none-any.whl (69 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 69.2/69.2 KB 3.9 MB/s eta 0:00:00
WARNING: jsonschema 4.1.2 does not provide the extra 'format-nongpl'
  Downloading jsonschema-4.1.1-py3-none-any.whl (69 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 69.2/69.2 KB 3.8 MB/s eta 0:00:00
WARNING: jsonschema 4.1.1 does not provide the extra 'format-nongpl'
  Downloading jsonschema-4.1.0-py3-none-any.whl (69 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 69.2/69.2 KB 3.8 MB/s eta 0:00:00
WARNING: jsonschema 4.1.0 does not provide the extra 'format-nongpl'
  Downloading jsonschema-4.0.1-py3-none-any.whl (69 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 69.1/69.1 KB 3.7 MB/s eta 0:00:00
WARNING: jsonschema 4.0.1 does not provide the extra 'format-nongpl'
WARNING: jsonschema 3.2.0 does not provide the extra 'format-nongpl'
Building wheels for collected packages: jax
  Building wheel for jax (pyproject.toml) ... done
  Created wheel for jax: filename=jax-0.4.8-py3-none-any.whl size=1439678 sha256=e3d43ff25dbccfb5f1dd6a4f5d99c174a77ad545bd01dc780bc55ed211e69601
  Stored in directory: /Users/sue/Library/Caches/pip/wheels/45/83/1e/3db22c5e1941c10e41c4f5cdf829b0a358146d4d0733d4a105
Successfully built jax
Installing collected packages: webencodings, wcwidth, tensorboard-plugin-wit, Send2Trash, pytz, pyfarmhash, pyasn1, ptyprocess, pickleshare, mistune, libclang, joblib, ipython-genutils, flatbuffers, fastjsonschema, docopt, crcmod, backcall, appnope, zstandard, zipp, wrapt, wheel, websocket-client, urllib3, uritemplate, typing-extensions, traitlets, tornado, tinycss2, termcolor, tensorflow-io-gcs-filesystem, tensorflow-estimator, tensorboard-data-server, sqlparse, soupsieve, sniffio, six, rsa, rfc3986-validator, regex, pyzmq, pyyaml, python-json-logger, pyrsistent, pyparsing, pymongo, pygments, pycparser, pyasn1-modules, psutil, protobuf, prompt-toolkit, prometheus-client, platformdirs, pillow, pexpect, parso, pandocfilters, packaging, overrides, orjson, objsize, oauthlib, numpy, nest-asyncio, MarkupSafe, kiwisolver, keras, jupyterlab-widgets, jupyterlab-pygments, idna, grpcio, google-crc32c, gast, fonttools, fasteners, fastavro, dill, defusedxml, decorator, debugpy, cycler, cloudpickle, charset-normalizer, certifi, cachetools, attrs, werkzeug, terminado, scipy, rfc3339-validator, requests, python-dateutil, pydot, pyarrow, proto-plus, opt-einsum, ml-dtypes, matplotlib-inline, jupyter-core, jsonschema, jinja2, jedi, importlib-resources, importlib-metadata, httplib2, h5py, googleapis-common-protos, google-resumable-media, google-pasta, google-auth, contourpy, comm, cffi, bleach, beautifulsoup4, astunparse, anyio, absl-py, tensorflow-metadata, requests-oauthlib, pandas, oauth2client, nbformat, ml-metadata, matplotlib, markdown, jupyter-server-terminals, jupyter-client, jax, ipython, hdfs, grpcio-status, google-auth-httplib2, google-api-core, argon2-cffi-bindings, nbclient, jupyter-events, ipykernel, grpc-google-iam-v1, google-cloud-core, google-auth-oauthlib, google-apitools, google-api-python-client, argon2-cffi, apache-beam, tensorboard, nbconvert, google-cloud-vision, google-cloud-videointelligence, google-cloud-spanner, google-cloud-recommendations-ai, google-cloud-pubsub, google-cloud-language, google-cloud-dlp, google-cloud-datastore, google-cloud-bigtable, google-cloud-bigquery-storage, google-cloud-bigquery, tensorflow, jupyter-server, google-cloud-pubsublite, tensorflow-serving-api, notebook-shim, tfx-bsl, nbclassic, tensorflow-data-validation, notebook, widgetsnbextension, ipywidgets, tensorflow-model-analysis, model-card-toolkit
Successfully installed MarkupSafe-2.1.2 Send2Trash-1.8.0 absl-py-1.0.0 anyio-3.6.2 apache-beam-2.46.0 appnope-0.1.3 argon2-cffi-21.3.0 argon2-cffi-bindings-21.2.0 astunparse-1.6.3 attrs-21.4.0 backcall-0.2.0 beautifulsoup4-4.12.0 bleach-6.0.0 cachetools-4.2.4 certifi-2022.12.7 cffi-1.15.1 charset-normalizer-3.1.0 cloudpickle-2.2.1 comm-0.1.3 contourpy-1.0.7 crcmod-1.7 cycler-0.11.0 debugpy-1.6.6 decorator-5.1.1 defusedxml-0.7.1 dill-0.3.1.1 docopt-0.6.2 fastavro-1.7.3 fasteners-0.18 fastjsonschema-2.16.3 flatbuffers-23.3.3 fonttools-4.39.3 gast-0.4.0 google-api-core-2.11.0 google-api-python-client-1.12.11 google-apitools-0.5.31 google-auth-2.17.1 google-auth-httplib2-0.1.0 google-auth-oauthlib-1.0.0 google-cloud-bigquery-3.9.0 google-cloud-bigquery-storage-2.16.2 google-cloud-bigtable-1.7.3 google-cloud-core-2.3.2 google-cloud-datastore-1.15.5 google-cloud-dlp-3.12.1 google-cloud-language-1.3.2 google-cloud-pubsub-2.15.2 google-cloud-pubsublite-1.8.1 google-cloud-recommendations-ai-0.7.1 google-cloud-spanner-3.29.0 google-cloud-videointelligence-1.16.3 google-cloud-vision-3.4.1 google-crc32c-1.5.0 google-pasta-0.2.0 google-resumable-media-2.4.1 googleapis-common-protos-1.59.0 grpc-google-iam-v1-0.12.6 grpcio-1.53.0 grpcio-status-1.48.2 h5py-3.8.0 hdfs-2.7.0 httplib2-0.21.0 idna-3.4 importlib-metadata-6.1.0 importlib-resources-5.12.0 ipykernel-6.22.0 ipython-7.34.0 ipython-genutils-0.2.0 ipywidgets-7.7.5 jax-0.4.8 jedi-0.18.2 jinja2-3.1.2 joblib-0.14.1 jsonschema-3.2.0 jupyter-client-8.1.0 jupyter-core-5.3.0 jupyter-events-0.6.3 jupyter-server-2.5.0 jupyter-server-terminals-0.4.4 jupyterlab-pygments-0.2.2 jupyterlab-widgets-1.1.4 keras-2.12.0 kiwisolver-1.4.4 libclang-16.0.0 markdown-3.4.3 matplotlib-3.7.1 matplotlib-inline-0.1.6 mistune-2.0.5 ml-dtypes-0.0.4 ml-metadata-1.12.0 model-card-toolkit-2.0.0rc0 nbclassic-0.5.4 nbclient-0.7.2 nbconvert-7.2.10 nbformat-5.8.0 nest-asyncio-1.5.6 notebook-6.5.3 notebook-shim-0.2.2 numpy-1.23.5 oauth2client-4.1.3 oauthlib-3.2.2 objsize-0.6.1 opt-einsum-3.3.0 orjson-3.8.9 overrides-6.5.0 packaging-23.0 pandas-1.5.3 pandocfilters-1.5.0 parso-0.8.3 pexpect-4.8.0 pickleshare-0.7.5 pillow-9.5.0 platformdirs-3.2.0 prometheus-client-0.16.0 prompt-toolkit-3.0.38 proto-plus-1.22.2 protobuf-3.20.3 psutil-5.9.4 ptyprocess-0.7.0 pyarrow-6.0.1 pyasn1-0.4.8 pyasn1-modules-0.2.8 pycparser-2.21 pydot-1.4.2 pyfarmhash-0.3.2 pygments-2.14.0 pymongo-3.13.0 pyparsing-3.0.9 pyrsistent-0.19.3 python-dateutil-2.8.2 python-json-logger-2.0.7 pytz-2023.3 pyyaml-6.0 pyzmq-25.0.2 regex-2023.3.23 requests-2.28.2 requests-oauthlib-1.3.1 rfc3339-validator-0.1.4 rfc3986-validator-0.1.1 rsa-4.9 scipy-1.10.1 six-1.16.0 sniffio-1.3.0 soupsieve-2.4 sqlparse-0.4.3 tensorboard-2.12.1 tensorboard-data-server-0.7.0 tensorboard-plugin-wit-1.8.1 tensorflow-2.12.0 tensorflow-data-validation-1.10.0 tensorflow-estimator-2.12.0 tensorflow-io-gcs-filesystem-0.32.0 tensorflow-metadata-1.10.0 tensorflow-model-analysis-0.41.1 tensorflow-serving-api-2.10.1 termcolor-2.2.0 terminado-0.17.1 tfx-bsl-1.10.1 tinycss2-1.2.1 tornado-6.2 traitlets-5.9.0 typing-extensions-4.5.0 uritemplate-3.0.1 urllib3-1.26.15 wcwidth-0.2.6 webencodings-0.5.1 websocket-client-1.5.1 werkzeug-2.2.3 wheel-0.40.0 widgetsnbextension-3.6.4 wrapt-1.14.1 zipp-3.15.0 zstandard-0.20.
</code></pre>
</details>

### Ran example notebooks in Colab

- [Standalone Model Card Toolkit Demo Gist](https://gist.github.com/codesue/b6a27bd97f8042a4ee9d001432be95c3)
- [Scikit-Learn Model Card Toolkit Demo Gist](https://gist.github.com/codesue/4ef3148e29f8d5c5c099ce4ee426a98d)

## How did you document this change?

N/A

## Before submitting

Before submitting a pull request, please be sure to do the following:
- [ ] Read the [How to Contribute guide](https://github.com/tensorflow/model-card-toolkit/blob/main/CONTRIBUTING.md) if this is your first contribution.
- [ ] Open an issue or discussion topic to discuss this change.
- [ ] Write new tests if applicable.
- [ ] Update documentation if applicable.