### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,10 +20,8 @@ Run with `python3 setup.py sdist bdist_wheel`.
 import platform
 import shutil
 import subprocess
-# TODO(b/188859752): deprecate distutils
-from distutils.command import build
+from setuptools.command.build import build
 
-from setuptools import Command, setup
 
 REQUIRED_PACKAGES = [
     'absl-py>=0.9,<1.1',


### PR DESCRIPTION
I made change in line 23 - 25 changed **Distutils**  to **setuptools**

# What does this pull request do?
This pull request deprecates the use of distutils and replaces it with setuptools, in line with the TODO note in the code (b/188859752)

## How did you document this change?
I updated the import statement to import Command and setup from setuptools, and removed the import statement for build from distutils. This change is necessary because distutils has been deprecated and is no longer supported in Python 3. setuptools provide more functionality.

## Before submitting

Before submitting a pull request, please be sure to do the following:
- [x] Read the [How to Contribute guide](https://github.com/tensorflow/model-card-toolkit/blob/main/CONTRIBUTING.md) if this is your first contribution.
- [ ] Open an issue or discussion topic to discuss this change.
- [ ] Write new tests if applicable.
- [ ] Update documentation if applicable.
