### PR TITLE
Add .from_proto() and .from_json() class methods

### DIFF
--- a/model_card_toolkit/base_model_card_field.py
+++ b/model_card_toolkit/base_model_card_field.py
@@ -20,11 +20,15 @@ see model_card.py).
 import abc
 import dataclasses
 import json as json_lib
-from typing import Any, Dict
+from textwrap import dedent
+from typing import Any, Dict, Type, TypeVar
+from warnings import warn
 
 from google.protobuf import descriptor, message
 
 from model_card_toolkit.utils import json_utils
+
+T = TypeVar('T', bound='BaseModelCardField')
 
 
 class BaseModelCardField(abc.ABC):
@@ -32,7 +36,7 @@ class BaseModelCardField(abc.ABC):
 
   This is an abstract class. All the model card fields should inherit this class
   and override the _proto_type property to the corresponding proto type. This
-  abstract class provides methods `copy_from_proto`, `merge_from_proto` and
+  abstract class provides methods `from_proto`, `merge_from_proto` and
   `to_proto` to convert the class from and to proto. The child class does not
   need to override this unless it needs some special process.
   """
@@ -55,7 +59,7 @@ class BaseModelCardField(abc.ABC):
     for field_name, field_value in self.__dict__.items():
       if not hasattr(proto, field_name):
         raise ValueError(
-            "%s has no such field named '%s'." % (type(proto), field_name)
+            '%s has no such field named "%s".' % (type(proto), field_name)
         )
       if not field_value:
         continue
@@ -80,11 +84,11 @@ class BaseModelCardField(abc.ABC):
 
     return proto
 
-  def _from_proto(self, proto: message.Message) -> "BaseModelCardField":
+  def _from_proto(self: T, proto: message.Message) -> T:
     """Convert proto to this class object."""
     if not isinstance(proto, self._proto_type):
       raise TypeError(
-          "%s is expected. However %s is provided." %
+          '%s is expected. However %s is provided.' %
           (self._proto_type, type(proto))
       )
 
@@ -92,7 +96,7 @@ class BaseModelCardField(abc.ABC):
       field_name = field_descriptor.name
       if not hasattr(self, field_name):
         raise ValueError(
-            "%s has no such field named '%s.'" % (self, field_name)
+            '%s has no such field named "%s".' % (self, field_name)
         )
 
       # Process Message type.
@@ -120,28 +124,44 @@ class BaseModelCardField(abc.ABC):
 
     return self
 
-  def merge_from_proto(self, proto: message.Message) -> "BaseModelCardField":
+  def merge_from_proto(self: T, proto: message.Message) -> T:
     """Merges the contents of the model card proto into current object."""
     current = self.to_proto()
     current.MergeFrom(proto)
     self.clear()
     return self._from_proto(current)
 
-  def copy_from_proto(self, proto: message.Message) -> "BaseModelCardField":
+  def copy_from_proto(self: T, proto: message.Message) -> T:
     """Copies the contents of the model card proto into current object."""
+    notice = dedent(
+        '''
+        This function is deprecated and will be removed in a future version.
+
+        If you would like to create a new model card from a proto, please use
+        `ModelCard.from_proto(proto)` instead.
+
+        If you would like to copy the contents of a proto into an existing model
+        card, please use `model_card.clear()` and `model_card.merge_from_proto(proto)`
+        instead.
+        '''
+    )
+    warn(notice, DeprecationWarning, stacklevel=2)
     self.clear()
     return self._from_proto(proto)
 
-  def _from_json(
-      self, json_dict: Dict[str, Any], field: "BaseModelCardField"
-  ) -> "BaseModelCardField":
+  @classmethod
+  def from_proto(cls: Type[T], proto: message.Message) -> T:
+    """Constructs an object of this class from a model card proto."""
+    return cls()._from_proto(proto)
+
+  def _from_json(self: T, json_dict: Dict[str, Any], field: T) -> T:
     """Parses a JSON dictionary into the current object."""
     for subfield_key, subfield_json_value in json_dict.items():
       if subfield_key.startswith(json_utils.SCHEMA_VERSION_STRING):
         continue
       elif not hasattr(field, subfield_key):
         raise ValueError(
-            "BaseModelCardField %s has no such field named '%s.'" %
+            'BaseModelCardField %s has no such field named "%s".' %
             (field, subfield_key)
         )
       elif isinstance(subfield_json_value, dict):

--- a/model_card_toolkit/core.py
+++ b/model_card_toolkit/core.py
@@ -193,7 +193,7 @@ class ModelCardToolkit():
     model_card_proto = model_card_pb2.ModelCard()
     with open(path, 'rb') as f:
       model_card_proto.ParseFromString(f.read())
-    return ModelCard().copy_from_proto(model_card_proto)
+    return ModelCard.from_proto(model_card_proto)
 
   def _annotate_eval_results(self, model_card: ModelCard) -> ModelCard:
     """Annotates a model card with info from TFMA evaluation results.

--- a/model_card_toolkit/model_card_test.py
+++ b/model_card_toolkit/model_card_test.py
@@ -37,10 +37,9 @@ _FULL_JSON = model_card_json_bytestring = pkgutil.get_data(
 
 
 class ModelCardTest(absltest.TestCase):
-  def test_copy_from_proto_and_to_proto_with_all_fields(self):
+  def test_from_proto_and_to_proto_with_all_fields(self):
     want_proto = text_format.Parse(_FULL_PROTO, model_card_pb2.ModelCard())
-    model_card_py = model_card.ModelCard()
-    model_card_py.copy_from_proto(want_proto)
+    model_card_py = model_card.ModelCard.from_proto(want_proto)
     got_proto = model_card_py.to_proto()
 
     self.assertEqual(want_proto, got_proto)
@@ -53,23 +52,27 @@ class ModelCardTest(absltest.TestCase):
 
     self.assertEqual(want_proto, got_proto)
 
-  def test_copy_from_proto_success(self):
+  def test_copy_from_proto_shows_deprecation_warning(self):
+    with self.assertWarns(DeprecationWarning):
+      owner = model_card.Owner(name="my_name1")
+      owner_proto = model_card_pb2.Owner(
+          name="my_name2", contact="my_contact2"
+      )
+      owner.copy_from_proto(owner_proto)
+
+  def test_from_proto_success(self):
     # Test fields convert.
-    owner = model_card.Owner(name="my_name1")
     owner_proto = model_card_pb2.Owner(name="my_name2", contact="my_contact2")
-    owner.copy_from_proto(owner_proto)
+    owner = model_card.Owner.from_proto(owner_proto)
     self.assertEqual(
         owner, model_card.Owner(name="my_name2", contact="my_contact2")
     )
 
     # Test message convert.
-    model_details = model_card.ModelDetails(
-        owners=[model_card.Owner(name="my_name1")]
-    )
     model_details_proto = model_card_pb2.ModelDetails(
         owners=[model_card_pb2.Owner(name="my_name2", contact="my_contact2")]
     )
-    model_details.copy_from_proto(model_details_proto)
+    model_details = model_card.ModelDetails.from_proto(model_details_proto)
     self.assertEqual(
         model_details,
         model_card.ModelDetails(
@@ -104,8 +107,7 @@ class ModelCardTest(absltest.TestCase):
         )
     )
 
-  def test_copy_from_proto_with_invalid_proto(self):
-    owner = model_card.Owner()
+  def test_from_proto_with_invalid_proto(self):
     wrong_proto = model_card_pb2.Version()
     with self.assertRaisesRegex(
         TypeError,
@@ -113,7 +115,7 @@ class ModelCardTest(absltest.TestCase):
         "However <class 'model_card_toolkit.proto.model_card_pb2.Version'> is "
         "provided."
     ):
-      owner.copy_from_proto(wrong_proto)
+      model_card.Owner.from_proto(wrong_proto)
 
   def test_merge_from_proto_with_invalid_proto(self):
     owner = model_card.Owner()
@@ -152,33 +154,15 @@ class ModelCardTest(absltest.TestCase):
     owner = model_card.Owner()
     owner.wrong_field = "wrong"
     with self.assertRaisesRegex(
-        ValueError, "has no such field named 'wrong_field'."
+        ValueError, "has no such field named \"wrong_field\"."
     ):
       owner.to_proto()
 
   def test_from_json_and_to_json_with_all_fields(self):
     want_json = json.loads(_FULL_JSON)
-    model_card_py = model_card.ModelCard()
-    model_card_py.from_json(want_json)
+    model_card_py = model_card.ModelCard.from_json(want_json)
     got_json = json.loads(model_card_py.to_json())
     self.assertEqual(want_json, got_json)
-
-  def test_from_json_overwrites_previous_fields(self):
-    overwritten_limitation = model_card.Limitation(
-        description="This model can only be used on text up to 140 characters."
-    )
-    overwritten_user = model_card.User(description="language researchers")
-    model_card_py = model_card.ModelCard(
-        considerations=model_card.Considerations(
-            limitations=[overwritten_limitation], users=[overwritten_user]
-        )
-    )
-    model_card_json = json.loads(_FULL_JSON)
-    model_card_py.from_json(model_card_json)
-    self.assertNotIn(
-        overwritten_limitation, model_card_py.considerations.limitations
-    )
-    self.assertNotIn(overwritten_user, model_card_py.considerations.users)
 
   def test_merge_from_json_does_not_overwrite_all_fields(self):
     # We want the "Limitations" field to be overwritten, but not "Users".
@@ -222,7 +206,7 @@ class ModelCardTest(absltest.TestCase):
   def test_from_invalid_json(self):
     invalid_json_dict = {"model_name": "the_greatest_model"}
     with self.assertRaises(jsonschema.ValidationError):
-      model_card.ModelCard().from_json(invalid_json_dict)
+      model_card.ModelCard.from_json(invalid_json_dict)
 
   def test_from_invalid_json_vesion(self):
     model_card_dict = {
@@ -238,7 +222,7 @@ class ModelCardTest(absltest.TestCase):
             "model card."
         )
     ):
-      model_card.ModelCard().from_json(model_card_dict)
+      model_card.ModelCard.from_json(model_card_dict)
 
   def test_from_proto_to_json(self):
     model_card_proto = text_format.Parse(
@@ -251,10 +235,10 @@ class ModelCardTest(absltest.TestCase):
         _FULL_JSON,
         model_card_py.merge_from_proto(model_card_proto).to_json()
     )
-    # Use copy_from_proto
+    # Use from_proto
     self.assertJsonEqual(
         _FULL_JSON,
-        model_card_py.copy_from_proto(model_card_proto).to_json()
+        model_card.ModelCard.from_proto(model_card_proto).to_json()
     )
 
   def test_from_json_to_proto(self):
@@ -263,8 +247,7 @@ class ModelCardTest(absltest.TestCase):
     )
 
     model_card_json = json.loads(_FULL_JSON)
-    model_card_py = model_card.ModelCard()
-    model_card_py.from_json(model_card_json)
+    model_card_py = model_card.ModelCard.from_json(model_card_json)
     model_card_json2proto = model_card_py.to_proto()
 
     self.assertEqual(model_card_proto, model_card_json2proto)


### PR DESCRIPTION
# What does this pull request do?

This pull request adds `BaseModelCardField.from_proto()` and makes `ModelCard().from_json()` a class method. It deprecates but doesn't remove `BaseModelCardField.copy_from_proto()`.

These are commonly used as alternative constructors, but in a roundabout way:

```python

model_card = ModelCard()
model_card.from_json(model_card_json)

owner = Owner()
owner.copy_from_proto(owner_proto)
```

Additionally, both `.from_json()` and `.copy_from_proto()` call `.clear()` before copying contents from the JSON/proto into these empty objects.

New usage:

```python

model_card = ModelCard.from_json(model_card_json)

owner = Owner.from_proto(owner_proto)
```

Relates to #276

## How did you test this change?

Updated tests and ran `pytest model_card_toolkit`.

## How did you document this change?

Updated docstrings.

## Before submitting

Before submitting a pull request, please be sure to do the following:
- [x] Read the [How to Contribute guide](https://github.com/tensorflow/model-card-toolkit/blob/main/CONTRIBUTING.md) if this is your first contribution.
- [x] Open an issue or discussion topic to discuss this change.
- [x] Write new tests if applicable.
- [x] Update documentation if applicable.
