### PR TITLE
[depends on #280] Add method for rendering model cards

### DIFF
--- a/model_card_toolkit/__init__.py
+++ b/model_card_toolkit/__init__.py
@@ -17,13 +17,12 @@ from model_card_toolkit.model_card import (
     Citation, ConfidenceInterval, Considerations, Dataset, Graphic,
     GraphicsCollection, KeyVal, License, Limitation, ModelCard, ModelDetails,
     ModelParameters, Owner, PerformanceMetric, QuantitativeAnalysis, Reference,
-    Risk, SensitiveData, Tradeoff, UseCase, User, Version
+    Risk, SensitiveData, Tradeoff, UseCase, User, Version, load_model_card
 )
 from model_card_toolkit.tfx.component import ModelCardGenerator
 from model_card_toolkit.version import __version__
 
 __all__ = [
-    '__version__',
     'Citation',
     'ConfidenceInterval',
     'Considerations',
@@ -48,4 +47,6 @@ __all__ = [
     'UseCase',
     'User',
     'Version',
+    '__version__',
+    'load_model_card',
 ]

--- a/model_card_toolkit/core.py
+++ b/model_card_toolkit/core.py
@@ -394,8 +394,6 @@ class ModelCardToolkit():
     """
     if not template_path:
       template_path = self.default_template
-    template_dir = os.path.dirname(template_path)
-    template_file = os.path.basename(template_path)
     if not output_file:
       output_file = _DEFAULT_MODEL_CARD_FILE_NAME
 
@@ -412,20 +410,10 @@ class ModelCardToolkit():
             'Call scaffold_assets() to generate a Model Card.'
         ) from e
 
-    # Generate Model Card.
-    jinja_env = jinja2.Environment(
-        loader=self._jinja_loader(template_dir), autoescape=True,
-        auto_reload=True, cache_size=0
-    )
-    template = jinja_env.get_template(template_file)
-    model_card_file_content = template.render(
-        model_details=model_card.model_details,
-        model_parameters=model_card.model_parameters,
-        quantitative_analysis=model_card.quantitative_analysis,
-        considerations=model_card.considerations
+    # Generate model card document.
+    model_card_file_content = model_card.render(
+      template_path=template_path,
+      output_path=os.path.join(self._model_cards_dir, output_file),
     )
 
-    # Write the model card document file and return its contents.
-    model_card_file_path = os.path.join(self._model_cards_dir, output_file)
-    io_utils.write_file(model_card_file_path, model_card_file_content)
     return model_card_file_content

--- a/model_card_toolkit/core_test.py
+++ b/model_card_toolkit/core_test.py
@@ -20,6 +20,7 @@ from absl.testing import absltest
 
 from model_card_toolkit import core
 from model_card_toolkit.proto import model_card_pb2
+from model_card_toolkit.utils import io_utils
 
 
 class CoreTest(absltest.TestCase):
@@ -61,9 +62,9 @@ class CoreTest(absltest.TestCase):
     mct.update_model_card(valid_model_card)
     proto_path = os.path.join(self.mct_dir, 'data/model_card.proto')
 
-    model_card_proto = model_card_pb2.ModelCard()
-    with open(proto_path, 'rb') as f:
-      model_card_proto.ParseFromString(f.read())
+    model_card_proto = io_utils.parse_proto_file(
+        proto_path, model_card_pb2.ModelCard()
+    )
     self.assertEqual(model_card_proto, valid_model_card.to_proto())
 
   def test_update_model_card_with_valid_model_card_as_proto(self):
@@ -74,9 +75,9 @@ class CoreTest(absltest.TestCase):
     mct.update_model_card(valid_model_card)
     proto_path = os.path.join(self.mct_dir, 'data/model_card.proto')
 
-    model_card_proto = model_card_pb2.ModelCard()
-    with open(proto_path, 'rb') as f:
-      model_card_proto.ParseFromString(f.read())
+    model_card_proto = io_utils.parse_proto_file(
+        proto_path, model_card_pb2.ModelCard()
+    )
     self.assertEqual(model_card_proto, valid_model_card)
 
   def test_export_format(self):
@@ -88,17 +89,17 @@ class CoreTest(absltest.TestCase):
 
     proto_path = os.path.join(self.mct_dir, 'data/model_card.proto')
     self.assertTrue(os.path.exists(proto_path))
-    with open(proto_path, 'rb') as f:
-      model_card_proto = model_card_pb2.ModelCard()
-      model_card_proto.ParseFromString(f.read())
-      self.assertEqual(model_card_proto.model_details.name, 'My Model')
+    model_card_proto = io_utils.parse_proto_file(
+        proto_path, model_card_pb2.ModelCard()
+    )
+    self.assertEqual(model_card_proto.model_details.name, 'My Model')
+
     model_card_path = os.path.join(self.mct_dir, 'model_cards/model_card.html')
     self.assertTrue(os.path.exists(model_card_path))
-    with open(model_card_path) as f:
-      content = f.read()
-      self.assertEqual(content, result)
-      self.assertTrue(content.startswith('<!DOCTYPE html>'))
-      self.assertIn('My Model', content)
+    content = io_utils.read_file(model_card_path)
+    self.assertEqual(content, result)
+    self.assertTrue(content.startswith('<!DOCTYPE html>'))
+    self.assertIn('My Model', content)
 
   def test_export_format_with_customized_template_and_output_name(self):
     mct = core.ModelCardToolkit(output_dir=self.mct_dir)
@@ -116,11 +117,10 @@ class CoreTest(absltest.TestCase):
 
     model_card_path = os.path.join(self.mct_dir, 'model_cards', output_file)
     self.assertTrue(os.path.exists(model_card_path))
-    with open(model_card_path) as f:
-      content = f.read()
-      self.assertEqual(content, result)
-      self.assertTrue(content.startswith('<!DOCTYPE html>'))
-      self.assertIn('My Model', content)
+    content = io_utils.read_file(model_card_path)
+    self.assertEqual(content, result)
+    self.assertTrue(content.startswith('<!DOCTYPE html>'))
+    self.assertIn('My Model', content)
 
   def test_export_format_before_scaffold_assets(self):
     with self.assertRaises(ValueError):

--- a/model_card_toolkit/documentation/guide/concepts.md
+++ b/model_card_toolkit/documentation/guide/concepts.md
@@ -55,6 +55,31 @@ object.
 The `model_card_toolkit.utils.graphics.figure_to_base64str()` function can be
 used to convert graphics, such as Matplotlib figures, to base64 strings.
 
+#### Saving and Loading Model Cards
+
+If you've finished annotating your model card and would like to serialize it in JSON
+or protobuf format, use the method `ModelCard.save()`.
+
+```python
+
+import model_card_toolkit as mct
+
+model_card = mct.ModelCard()
+model_card.model_details.name = 'Fine-tuned MobileNetV2 Model for Cats vs. Dogs'
+model_card.save('model_cards/cats_vs_dogs.json')
+```
+
+If you'd like to restore and update a saved model card, use the function
+`model_card_toolkit.model_card.load_model_card()`.
+
+```python
+
+import model_card_toolkit as mct
+
+model_card = mct.load_model_card('model_cards/cats_vs_dogs.json')
+model_card.model_details.licenses.append(mct.License(identifier='Apache-2.0'))
+```
+
 ### Model Card Documents
 
 By default, the generated model card document is a HTML file based on

--- a/model_card_toolkit/model_card.py
+++ b/model_card_toolkit/model_card.py
@@ -28,7 +28,7 @@ from typing import Any, Dict, List, Optional, Union
 
 from model_card_toolkit.base_model_card_field import BaseModelCardField
 from model_card_toolkit.proto import model_card_pb2
-from model_card_toolkit.utils import io_utils, json_utils
+from model_card_toolkit.utils import io_utils, json_utils, template_utils
 
 _SUPPORTED_SAVE_FORMATS = ('.json', '.proto')
 
@@ -544,6 +544,40 @@ class ModelCard(BaseModelCardField):
     model_card = cls()
     model_card._from_json(json_dict, model_card)
     return model_card
+
+  def render(
+      self,
+      template_path: Optional[Union[Path, str]] = None,
+      output_path: Optional[Union[Path, str]] = None,
+      template_variables: Optional[Dict[str, Any]] = None,
+  ) -> str:
+    """Renders the model card using a Jinja template.
+
+    Args:
+      template_path: The path to a Jinja template file. If not provided, the
+        default HTML template will be used.
+      output_path: The path to write the rendered template to. If not provided,
+        the rendered template will not be written to a file. If the file already
+        exists, it will be overwritten.
+      template_variables: A dictionary of variables to pass to the template in
+        addition to model card fields.
+
+    Returns:
+      The rendered model card as a string.
+    """
+    template_path = template_path or template_utils.default_html_template()
+    template_variables = template_variables or {}
+    return template_utils.render(
+        template_path=template_path,
+        output_path=output_path,
+        template_variables={
+            'model_details': self.model_details,
+            'model_parameters': self.model_parameters,
+            'quantitative_analysis': self.quantitative_analysis,
+            'considerations': self.considerations,
+            **template_variables,
+        },
+    )
 
   def save(self, path: Union[Path, str], overwrite: Optional[bool] = False):
     """Saves the model card to a file.

--- a/model_card_toolkit/model_card_test.py
+++ b/model_card_toolkit/model_card_test.py
@@ -24,15 +24,15 @@ from google.protobuf import text_format
 from model_card_toolkit import model_card
 from model_card_toolkit.proto import model_card_pb2
 
-_FULL_PROTO_FILE_NAME = "full.pbtxt"
+_FULL_PROTO_FILE_NAME = 'full.pbtxt'
 _FULL_PROTO = pkgutil.get_data(
-    "model_card_toolkit",
-    os.path.join("utils", "testdata", _FULL_PROTO_FILE_NAME)
+    'model_card_toolkit',
+    os.path.join('utils', 'testdata', _FULL_PROTO_FILE_NAME)
 )
-_FULL_JSON_FILE_PATH = "full.json"
+_FULL_JSON_FILE_PATH = 'full.json'
 _FULL_JSON = model_card_json_bytestring = pkgutil.get_data(
-    "model_card_toolkit",
-    os.path.join("utils", "testdata", _FULL_JSON_FILE_PATH)
+    'model_card_toolkit',
+    os.path.join('utils', 'testdata', _FULL_JSON_FILE_PATH)
 )
 
 
@@ -54,55 +54,55 @@ class ModelCardTest(absltest.TestCase):
 
   def test_copy_from_proto_shows_deprecation_warning(self):
     with self.assertWarns(DeprecationWarning):
-      owner = model_card.Owner(name="my_name1")
+      owner = model_card.Owner(name='my_name1')
       owner_proto = model_card_pb2.Owner(
-          name="my_name2", contact="my_contact2"
+          name='my_name2', contact='my_contact2'
       )
       owner.copy_from_proto(owner_proto)
 
   def test_from_proto_success(self):
     # Test fields convert.
-    owner_proto = model_card_pb2.Owner(name="my_name2", contact="my_contact2")
+    owner_proto = model_card_pb2.Owner(name='my_name2', contact='my_contact2')
     owner = model_card.Owner.from_proto(owner_proto)
     self.assertEqual(
-        owner, model_card.Owner(name="my_name2", contact="my_contact2")
+        owner, model_card.Owner(name='my_name2', contact='my_contact2')
     )
 
     # Test message convert.
     model_details_proto = model_card_pb2.ModelDetails(
-        owners=[model_card_pb2.Owner(name="my_name2", contact="my_contact2")]
+        owners=[model_card_pb2.Owner(name='my_name2', contact='my_contact2')]
     )
     model_details = model_card.ModelDetails.from_proto(model_details_proto)
     self.assertEqual(
         model_details,
         model_card.ModelDetails(
-            owners=[model_card.Owner(name="my_name2", contact="my_contact2")]
+            owners=[model_card.Owner(name='my_name2', contact='my_contact2')]
         )
     )
 
   def test_merge_from_proto_success(self):
     # Test fields convert.
-    owner = model_card.Owner(name="my_name1")
-    owner_proto = model_card_pb2.Owner(contact="my_contact1")
+    owner = model_card.Owner(name='my_name1')
+    owner_proto = model_card_pb2.Owner(contact='my_contact1')
     owner.merge_from_proto(owner_proto)
     self.assertEqual(
-        owner, model_card.Owner(name="my_name1", contact="my_contact1")
+        owner, model_card.Owner(name='my_name1', contact='my_contact1')
     )
 
     # Test message convert.
     model_details = model_card.ModelDetails(
-        owners=[model_card.Owner(name="my_name1")]
+        owners=[model_card.Owner(name='my_name1')]
     )
     model_details_proto = model_card_pb2.ModelDetails(
-        owners=[model_card_pb2.Owner(name="my_name2", contact="my_contact2")]
+        owners=[model_card_pb2.Owner(name='my_name2', contact='my_contact2')]
     )
     model_details.merge_from_proto(model_details_proto)
     self.assertEqual(
         model_details,
         model_card.ModelDetails(
             owners=[
-                model_card.Owner(name="my_name1"),
-                model_card.Owner(name="my_name2", contact="my_contact2")
+                model_card.Owner(name='my_name1'),
+                model_card.Owner(name='my_name2', contact='my_contact2')
             ]
         )
     )
@@ -111,9 +111,9 @@ class ModelCardTest(absltest.TestCase):
     wrong_proto = model_card_pb2.Version()
     with self.assertRaisesRegex(
         TypeError,
-        "<class 'model_card_toolkit.proto.model_card_pb2.Owner'> is expected. "
-        "However <class 'model_card_toolkit.proto.model_card_pb2.Version'> is "
-        "provided."
+        '<class \'model_card_toolkit.proto.model_card_pb2.Owner\'> is expected. '
+        'However <class \'model_card_toolkit.proto.model_card_pb2.Version\'> is '
+        'provided.'
     ):
       model_card.Owner.from_proto(wrong_proto)
 
@@ -121,7 +121,7 @@ class ModelCardTest(absltest.TestCase):
     owner = model_card.Owner()
     wrong_proto = model_card_pb2.Version()
     with self.assertRaisesRegex(
-        TypeError, ".*expected .*Owner got .*Version.*"
+        TypeError, '.*expected .*Owner got .*Version.*'
     ):
       owner.merge_from_proto(wrong_proto)
 
@@ -129,32 +129,32 @@ class ModelCardTest(absltest.TestCase):
     # Test fields convert.
     owner = model_card.Owner()
     self.assertEqual(owner.to_proto(), model_card_pb2.Owner())
-    owner.name = "my_name"
-    self.assertEqual(owner.to_proto(), model_card_pb2.Owner(name="my_name"))
-    owner.contact = "my_contact"
+    owner.name = 'my_name'
+    self.assertEqual(owner.to_proto(), model_card_pb2.Owner(name='my_name'))
+    owner.contact = 'my_contact'
     self.assertEqual(
         owner.to_proto(),
-        model_card_pb2.Owner(name="my_name", contact="my_contact")
+        model_card_pb2.Owner(name='my_name', contact='my_contact')
     )
 
     # Test message convert.
     model_details = model_card.ModelDetails(
-        owners=[model_card.Owner(name="my_name", contact="my_contact")]
+        owners=[model_card.Owner(name='my_name', contact='my_contact')]
     )
     self.assertEqual(
         model_details.to_proto(),
         model_card_pb2.ModelDetails(
             owners=[
-                model_card_pb2.Owner(name="my_name", contact="my_contact")
+                model_card_pb2.Owner(name='my_name', contact='my_contact')
             ]
         )
     )
 
   def test_to_proto_with_invalid_field(self):
     owner = model_card.Owner()
-    owner.wrong_field = "wrong"
+    owner.wrong_field = 'wrong'
     with self.assertRaisesRegex(
-        ValueError, "has no such field named \"wrong_field\"."
+        ValueError, 'has no such field named "wrong_field".'
     ):
       owner.to_proto()
 
@@ -169,9 +169,9 @@ class ModelCardTest(absltest.TestCase):
 
     # Initially, the ModelCard's "Limitations" and "Users" are specified.
     overwritten_limitation = model_card.Limitation(
-        description="This model can only be used on text up to 140 characters."
+        description='This model can only be used on text up to 140 characters.'
     )
-    not_overwritten_user = model_card.User(description="language researchers")
+    not_overwritten_user = model_card.User(description='language researchers')
     model_card_py = model_card.ModelCard(
         considerations=model_card.Considerations(
             limitations=[overwritten_limitation], users=[not_overwritten_user]
@@ -180,8 +180,8 @@ class ModelCardTest(absltest.TestCase):
 
     # We create a JSON that specifies "Limitations" but not "Users".
     model_card_json = json.loads(_FULL_JSON)
-    assert "limitations" in model_card_json["considerations"]
-    assert "users" not in model_card_json["considerations"]
+    assert 'limitations' in model_card_json['considerations']
+    assert 'users' not in model_card_json['considerations']
 
     # merge_from_json() overwrites ModelCard fields that were specified in JSON.
     # "Limitations" was specified, so it is overwritten, but "Users" is not.
@@ -204,22 +204,22 @@ class ModelCardTest(absltest.TestCase):
     self.assertEqual(model_card_from_dict, model_card_from_str)
 
   def test_from_invalid_json(self):
-    invalid_json_dict = {"model_name": "the_greatest_model"}
+    invalid_json_dict = {'model_name': 'the_greatest_model'}
     with self.assertRaises(jsonschema.ValidationError):
       model_card.ModelCard.from_json(invalid_json_dict)
 
   def test_from_invalid_json_vesion(self):
     model_card_dict = {
-        "model_details": {},
-        "model_parameters": {},
-        "quantitative_analysis": {},
-        "considerations": {},
-        "schema_version": "0.0.3"
+        'model_details': {},
+        'model_parameters': {},
+        'quantitative_analysis': {},
+        'considerations': {},
+        'schema_version': '0.0.3'
     }
     with self.assertRaisesRegex(
         ValueError, (
-            "^Cannot find schema version that matches the version of the given "
-            "model card."
+            '^Cannot find schema version that matches the version of the given '
+            'model card.'
         )
     ):
       model_card.ModelCard.from_json(model_card_dict)
@@ -252,6 +252,43 @@ class ModelCardTest(absltest.TestCase):
 
     self.assertEqual(model_card_proto, model_card_json2proto)
 
+  def test_save_and_load_model_card(self):
+    temp_dir = self.create_tempdir()
+    model_card_py = model_card.ModelCard(
+        model_details=model_card.ModelDetails(name='an awesome model')
+    )
 
-if __name__ == "__main__":
+    with self.subTest('save and load from json'):
+      json_path = os.path.join(temp_dir, 'awesome_model_model_card.json')
+      model_card_py.save(json_path)
+      loaded_from_json = model_card.load_model_card(json_path)
+      self.assertEqual(model_card_py, loaded_from_json)
+
+    with self.subTest('save and load from proto'):
+      proto_path = os.path.join(temp_dir, 'awesome_model_model_card.proto')
+      model_card_py.save(proto_path)
+      loaded_from_proto = model_card.load_model_card(proto_path)
+      self.assertEqual(model_card_py, loaded_from_proto)
+
+    with self.subTest('save and load unsupported format'):
+      unsupported_path = os.path.join(temp_dir, 'awesome_model_model_card.xyz')
+      with self.assertRaisesRegex(ValueError, 'Unsupported file format'):
+        model_card_py.save(unsupported_path)
+      with self.assertRaisesRegex(ValueError, 'Unsupported file format'):
+        model_card.load_model_card(unsupported_path)
+
+  def test_save_model_card_with_overwrite(self):
+    path = os.path.join(self.create_tempdir(), 'model_card.json')
+    model_card_py = model_card.ModelCard()
+    with open(path, 'w') as f:
+      f.write('{"key": "key", "value": "value"}')
+    assert os.path.exists(path)
+
+    model_card_py.save(path, overwrite=True)
+
+    with self.assertRaisesRegex(ValueError, f'{path} already exists'):
+      model_card_py.save(path)
+
+
+if __name__ == '__main__':
   absltest.main()

--- a/model_card_toolkit/model_card_test.py
+++ b/model_card_toolkit/model_card_test.py
@@ -252,6 +252,13 @@ class ModelCardTest(absltest.TestCase):
 
     self.assertEqual(model_card_proto, model_card_json2proto)
 
+  def test_render(self):
+    model_card_py = model_card.ModelCard()
+    model_card_py.model_details.overview = 'This is an example model.'
+    content = model_card_py.render()
+    self.assertTrue(content.startswith('<!DOCTYPE html>'))
+    self.assertIn('This is an example model.', content)
+
   def test_save_and_load_model_card(self):
     temp_dir = self.create_tempdir()
     model_card_py = model_card.ModelCard(

--- a/model_card_toolkit/utils/io_utils.py
+++ b/model_card_toolkit/utils/io_utils.py
@@ -1,0 +1,90 @@
+# Copyright 2023 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Utilities for reading and writing files."""
+
+import os
+from pathlib import Path
+from typing import Union
+
+from google.protobuf.message import Message
+
+
+def suffix(path: Union[str, Path]) -> str:
+  """Returns the suffix (extension) of a path."""
+  return os.path.splitext(path)[1]
+
+
+def write_file(
+    path: Union[str, Path], content: Union[str, bytes], mode: str = 'w'
+):
+  """Writes content to a file, creating any necessary directories.
+
+  Args:
+    path: The file path to write to
+    content: The content to write.
+    mode: The mode to open the file in. Defaults to 'w'.
+
+  Raises:
+    ValueError: If an invalid mode is provided.
+  """
+  os.makedirs(os.path.dirname(path), exist_ok=True)
+  with open(path, mode) as f:
+    f.write(content)
+
+
+def write_proto_file(path: Union[str, Path], proto: Message):
+  """Writes a message to a proto file, creating any necessary directories.
+
+  Args:
+    path: The file path to write the proto to.
+    proto: The proto to write.
+  """
+  write_file(path, proto.SerializeToString(), mode='wb')
+
+
+def read_file(path: Union[str, Path], mode: str = 'r') -> Union[str, bytes]:
+  """Reads a file and returns its content.
+
+  Args:
+    path: The file path to read from.
+    mode: The mode to open the file in. Defaults to 'r'.
+
+  Raises:
+    FileNotFoundError: If the file does not exist.
+    ValueError: If an invalid mode is provided.
+  """
+  if not os.path.exists(path):
+    raise FileNotFoundError(f'File {path} does not exist.')
+
+  with open(path, mode) as f:
+    return f.read()
+
+
+def parse_proto_file(path: Union[str, Path], proto: Message) -> Message:
+  """Parses a message from a proto file and returns the proto.
+
+  Args:
+    path: The file path to parse the proto from.
+    proto: The proto to parse into.
+
+  Raises:
+    FileNotFoundError: If the file does not exist.
+  """
+  if not os.path.exists(path):
+    raise FileNotFoundError(f'File {path} does not exist.')
+
+  with open(path, 'rb') as f:
+    proto.ParseFromString(f.read())
+  return proto

--- a/model_card_toolkit/utils/io_utils_test.py
+++ b/model_card_toolkit/utils/io_utils_test.py
@@ -1,0 +1,47 @@
+# Copyright 2023 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for model_card_toolkit.utils.io_utils."""
+
+import os
+import tempfile
+
+from absl.testing import absltest
+
+from model_card_toolkit.proto import model_card_pb2
+from model_card_toolkit.utils import io_utils
+
+
+class IoUtilsTest(absltest.TestCase):
+  def test_suffix(self):
+    self.assertEqual('.json', io_utils.suffix('test.json'))
+    self.assertEqual('.gz', io_utils.suffix('test.json.gz'))
+    self.assertEqual('', io_utils.suffix('test'))
+    self.assertEqual('', io_utils.suffix('.json'))
+
+  def test_write_and_read_file(self):
+    with tempfile.TemporaryDirectory() as test_dir:
+      path = os.path.join(test_dir, 'test.txt')
+      content = 'This is a sentence.'
+      io_utils.write_file(path, content)
+      read_content = io_utils.read_file(path)
+      self.assertEqual(content, read_content)
+
+  def test_write_and_parse_proto(self):
+    with tempfile.TemporaryDirectory() as test_dir:
+      path = os.path.join(test_dir, 'test.proto')
+      proto = model_card_pb2.KeyVal(key='key', value='value')
+      io_utils.write_proto_file(path, proto)
+      parsed_proto = io_utils.parse_proto_file(path, model_card_pb2.KeyVal())
+      self.assertEqual(proto, parsed_proto)

--- a/model_card_toolkit/utils/template_utils.py
+++ b/model_card_toolkit/utils/template_utils.py
@@ -1,0 +1,54 @@
+import os
+from pathlib import Path
+from typing import Any, Dict, Optional, Union
+
+try:
+  from importlib.resources import files
+except ImportError:
+  from importlib_resources import files
+
+import jinja2
+
+from model_card_toolkit.utils import io_utils
+
+def default_html_template() -> str:
+  return str(files('model_card_toolkit').joinpath(
+      'template', 'html', 'default_template.html.jinja'
+  ))
+
+
+def default_md_template() -> str:
+  return str(files('model_card_toolkit').joinpath(
+      'template', 'md', 'default_template.md.jinja'
+  ))
+
+def render(
+    template_path: Union[Path, str],
+    output_path: Optional[Union[Path, str]] = None,
+    template_variables: Optional[Dict[str, Any]] = None,
+) -> str:
+  """Renders a Jinja template and returns the content as a string.
+
+  Args:
+    template_path: The path to a Jinja template file.
+    output_path: The path to write the rendered template to. If not provided,
+      the rendered template will not be written to a file. If the file already
+      exists, it will be overwritten.
+    template_variables: A dictionary of variables to pass to the template.
+  """
+  template_variables = template_variables or {}
+  template_dir = os.path.dirname(template_path)
+  template_file = os.path.basename(template_path)
+  jinja_env = jinja2.Environment(
+      loader=jinja2.FileSystemLoader(template_dir),
+      autoescape=True,
+      auto_reload=True,
+      cache_size=0,
+  )
+
+  template = jinja_env.get_template(template_file)
+  content = template.render(template_variables)
+  if output_path:
+    io_utils.write_file(output_path, content)
+
+  return content

--- a/model_card_toolkit/utils/template_utils_test.py
+++ b/model_card_toolkit/utils/template_utils_test.py
@@ -1,0 +1,25 @@
+import os
+import tempfile
+
+from absl.testing import absltest
+
+from model_card_toolkit.utils import io_utils, template_utils
+
+class TemplateUtilsTest(absltest.TestCase):
+  def test_render(self):
+    with tempfile.TemporaryDirectory() as test_dir:
+      template_path = os.path.join(test_dir, 'test.txt.jinja')
+      io_utils.write_file(template_path, '{{ greeting }}, World!')
+      output_path = os.path.join(test_dir, 'test.txt')
+      content = template_utils.render(
+          template_path=template_path,
+          output_path=output_path,
+          template_variables={'greeting': 'Hello'}
+      )
+      read_content = io_utils.read_file(output_path)
+      self.assertTrue(os.path.exists(output_path))
+      self.assertEqual(content, read_content)
+      self.assertEqual(content, 'Hello, World!')
+
+if __name__ == '__main__':
+  absltest.main()

--- a/model_card_toolkit/utils/testdata/tfxtest.py
+++ b/model_card_toolkit/utils/testdata/tfxtest.py
@@ -27,6 +27,7 @@ from tensorflow_model_analysis.eval_saved_model.example_trainers import (
 )
 from tfx_bsl.tfxio import raw_tf_record
 
+from model_card_toolkit.utils import io_utils
 from model_card_toolkit.utils.tf_utils import (
     _TFX_METRICS_TYPE, _TFX_STATS_TYPE
 )
@@ -179,9 +180,7 @@ class TfxTest(tfma.eval_saved_model.testutil.TensorflowModelAnalysisTest):
           datasets=[stats]
       )
       stats_file = os.path.join(tfdv_path, split_name, 'FeatureStats.pb')
-      os.makedirs(os.path.dirname(stats_file), exist_ok=True)
-      with open(stats_file, mode='wb') as f:
-        f.write(stats_list.SerializeToString())
+      io_utils.write_proto_file(stats_file, stats_list)
 
     _write(train_dataset_name, train_features, 'Split-train')
     _write(eval_dataset_name, eval_features, 'Split-eval')


### PR DESCRIPTION
# What does this pull request do?

Adds a method for rendering model cards. This allows you to render a model card by calling `model_card.render()` without first having to first create a `ModelCardToolkit` object and scaffold assets (which copies default template files and creates a model card proto). Additionally, saving the rendered model card document to a file is optional with this method.

Current usage:

```
import model_card_toolkit as mct

toolkit = mct.ModelCardToolkit()
model_card = toolkit.scaffold_assets()
model_card.model_details.name = 'My Model'
model_card_html = toolkit.export_format()
```

With this change:

```
import model_card_toolkit as mct

model_card = mct.ModelCard()
model_card.model_details.name = 'My Model'
model_card_html = model_card.render()
```

Relates to https://github.com/tensorflow/model-card-toolkit/discussions/276.

## How did you test this change?

Added unit tests and ran `pytest model_card_toolkit`.
Example notebook: https://colab.research.google.com/gist/codesue/e315e2d79d564ed60a454b8509ca3c31/dev.ipynb

## How did you document this change?

Docstrings

## Before submitting

Before submitting a pull request, please be sure to do the following:
- [x] Read the [How to Contribute guide](https://github.com/tensorflow/model-card-toolkit/blob/main/CONTRIBUTING.md) if this is your first contribution.
- [x] Open an issue or discussion topic to discuss this change.
- [x] Write new tests if applicable.
- [x] Update documentation if applicable.
