### PR TITLE
Upgrade GitHub actions to Node 16

### DIFF
--- a/.github/workflows/cherrypick.yml
+++ b/.github/workflows/cherrypick.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
 
       - name: Checkout the latest code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0 # otherwise, you will fail to push refs to the dest repo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,13 +40,13 @@ jobs:
             tests: model_card_toolkit --fail-if-skipped
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.7
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: Cache python environment
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         # Cache pip
         path: ~/.cache/pip

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,8 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-    - uses: actions/checkout@v2
-    - uses: pre-commit/action@v2.0.3
+    - uses: actions/checkout@v3
+    - uses: pre-commit/action@v3.0.0
       name: Run pre-commit checks (pylint/yapf/isort)
       env:
         SKIP: insert-license

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
     container:
       image: gcr.io/tfx-oss-public/tfx_base:py37-20200729
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Build wheel
       run: |
@@ -30,7 +30,7 @@ jobs:
         MCT_WHEEL=$(find dist -name 'model_card_toolkit-*.whl'); \
 
     - name: Publish Model Card Toolkit distribution package to Test PyPI
-      uses: pypa/gh-action-pypi-publish@v1.5.0
+      uses: pypa/gh-action-pypi-publish@v1.8.6
       with:
         password: ${{ secrets.TEST_PYPI_API_TOKEN }}
         repository_url: https://test.pypi.org/legacy/
@@ -38,12 +38,12 @@ jobs:
 
     - name: Publish Model Card Toolkit distribution package to PyPI
       if: github.event_name == 'release'
-      uses: pypa/gh-action-pypi-publish@v1.5.0
+      uses: pypa/gh-action-pypi-publish@v1.8.6
       with:
         password: ${{ secrets.PYPI_API_TOKEN }}
 
     - name: Upload files to a GitHub release
-      uses: svenstaro/upload-release-action@2.2.1
+      uses: svenstaro/upload-release-action@2.6.1
       if: github.event_name == 'release'
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# What does this pull request do?

Updates workflows to use Node.js 16 actions ahead of the Node.js 12 deprecation.

Fixes #274

## How did you test this change?

Ran workflows triggered by pull requests.

## How did you document this change?

n/a

## Before submitting

Before submitting a pull request, please be sure to do the following:
- [x] Read the [How to Contribute guide](https://github.com/tensorflow/model-card-toolkit/blob/main/CONTRIBUTING.md) if this is your first contribution.
- [x] Open an issue or discussion topic to discuss this change.
- [x] Write new tests if applicable.
- [x] Update documentation if applicable.
