### PR TITLE
Resolve TODO for distutils migration as not applicable

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,6 @@
 import platform
 import shutil
 import subprocess
-# TODO(b/188859752): deprecate distutils
 from distutils.command import build
 
 from setuptools import Command, setup


### PR DESCRIPTION
# What does this pull request do?

Resolves the TODO to migrate setup.py from `distutils` to `setuptools` since it's not applicable. There isn't a good `setuptools` alternative yet for `distutils.command.build`, and we can continue to use `distutils` through `setuptools`' bundled copy after it's removed from the standard library. See https://github.com/pypa/setuptools/issues/2928.

Fixes #269

## How did you test this change?

n/a

## How did you document this change?

n/a

## Before submitting

Before submitting a pull request, please be sure to do the following:
- [x] Read the [How to Contribute guide](https://github.com/tensorflow/model-card-toolkit/blob/main/CONTRIBUTING.md) if this is your first contribution.
- [x] Open an issue or discussion topic to discuss this change.
- [x] Write new tests if applicable.
- [x] Update documentation if applicable.
